### PR TITLE
Add simple string <> string Thrift call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.6
 require go.k6.io/k6 v0.56.0
 
 require (
+	github.com/apache/thrift v0.21.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/evanw/esbuild v0.21.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+github.com/apache/thrift v0.21.0 h1:tdPmh/ptjE1IJnhbhrcl2++TauVjy242rkV/UzJChnE=
+github.com/apache/thrift v0.21.0/go.mod h1:W1H8aR/QRtYNvrPeFXBtobyRkd0/YVhTc6i07XIAgDw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/scripts/get_started.js
+++ b/scripts/get_started.js
@@ -6,5 +6,5 @@ export const options = {
 }
 
 export default function() {
-  thrift.echo("World");
+  thrift.echo();
 }

--- a/thrift.go
+++ b/thrift.go
@@ -1,8 +1,12 @@
 package thrift
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
+	"strconv"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"go.k6.io/k6/js/modules"
 )
 
@@ -12,6 +16,42 @@ func init() {
 
 type TModule struct{}
 
-func (m *TModule) Echo(arg string) {
-	fmt.Println("Hello " + arg)
+func (m *TModule) Echo() {
+	host := "127.0.0.1"
+	port := 8080
+	path := "/thrift"
+	method := "simpleCall"
+
+	tf := thrift.NewTHttpClientTransportFactory("http://" + host + ":" + strconv.Itoa(port) + path)
+	cfg := thrift.TConfiguration{
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	sock := thrift.NewTSocketConf("127.0.0.1:8080", &cfg)
+	transport, err := tf.GetTransport(sock)
+	if err != nil {
+		fmt.Println("ERROR: ", err)
+		return
+	}
+	pf := thrift.NewTBinaryProtocolFactoryConf(&cfg)
+	iprot := pf.GetProtocol(transport)
+	oprot := pf.GetProtocol(transport)
+	tclient := thrift.NewTStandardClient(iprot, oprot)
+	defer transport.Close()
+
+	err = transport.Open()
+	if err != nil {
+		fmt.Println("ERROR: ", err)
+		return
+	}
+
+	req := TString{}
+	res := TString{}
+	req.value = "request ID"
+
+	cxt := context.Background()
+	tclient.Call(cxt, method, &req, &res)
+
+	fmt.Println("Response: \"", res.value, "\"")
 }

--- a/tstring.go
+++ b/tstring.go
@@ -1,0 +1,112 @@
+package thrift
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type TString struct {
+	value string
+}
+
+func (p *TString) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 0:
+			if fieldTypeId == thrift.STRING {
+				if err := p.ReadField0(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 1:
+			if fieldTypeId == thrift.STRING {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *TString) ReadField0(ctx context.Context, iprot thrift.TProtocol) error {
+	v, err := iprot.ReadString(ctx)
+	fmt.Println("READ 0", v, err)
+	if err != nil {
+		return thrift.PrependError("error reading field 0: ", err)
+	} else {
+		p.value = v
+	}
+	return nil
+}
+
+func (p *TString) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadString(ctx); err != nil {
+		return thrift.PrependError("error reading field 1: ", err)
+	} else {
+		p.value = v
+	}
+	return nil
+}
+
+func (p *TString) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "simple_args"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *TString) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "id", thrift.STRING, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:id: ", p), err)
+	}
+	if err := oprot.WriteString(ctx, string(p.value)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.id (1) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:id: ", p), err)
+	}
+	return err
+}


### PR DESCRIPTION
# Overview

Add tiny simple Thrift client implementation.

# What's changed

- Add `TString` struct, which represents `string` in Thrift.
  - parses request/response to Golang struct.
  - comes from generated code. see `/server/thrift/build/generated-sources/thrift/gen-go/server_service.go`.
- Add Thrift client in `init()` function.
  - ignored clean code in this PR. will be refactored.

## Details

Thrift's architecture is like following diagram.
https://thrift.apache.org/docs/concepts.html

```
  +-------------------------------------------+
  | Server                                    |
  | (single-threaded, event-driven etc)       |
  +-------------------------------------------+
  | Processor                                 |
  | (compiler generated)                      |
  +-------------------------------------------+
  | Protocol                                  |
  | (JSON, compact etc)                       |
  +-------------------------------------------+
  | Transport                                 |
  | (raw TCP, HTTP etc)                       |
  +-------------------------------------------+
```

Thanks to the layered architecture, it's possible to call Thrift API by implementing `Processor (compiler generated)` processes, implementing `TStruct` interfaces and passing them as arguments.
So, the overall idea is...

- Use Thrift Golang client (`TStandardClient`).
- Only thing `xk6-thrift` should do is *mapping between original-defined Golang struct and Thrift TStruct*.
  - it will be archieved by implementing `TStruct` method, `Read` and `Write`.
  - Thrift client library handles following items. thus, it will be easy to use any kind of Transport / Protocol feature like (HTTP x JSON, TCP x TBINARY).
    - Transport
    - Protocol

## Run

### Run server

```
./server/gradlew run -p server/server
```

### Run xk6

```
$ xk6 run scripts/get_started.js
2025/02/09 18:26:06 INFO Building k6
2025/02/09 18:26:06 INFO Building new k6 binary (native)
2025/02/09 18:26:06 INFO Initializing Go module
go: creating new go.mod: module k6
2025/02/09 18:26:06 INFO replacing dependency github.com/lavenderses/xk6-thrift => /home/nakanoi/projects/xk6-thrift
2025/02/09 18:26:06 INFO Creating k6 main
2025/02/09 18:26:06 INFO adding dependency go.k6.io/k6@latest
go: finding module for package github.com/fsnotify/fsnotify
go: finding module for package gopkg.in/tomb.v1
go: found gopkg.in/tomb.v1 in gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: found github.com/fsnotify/fsnotify in github.com/fsnotify/fsnotify v1.8.0
2025/02/09 18:26:08 INFO importing extensions
2025/02/09 18:26:08 INFO adding dependency github.com/lavenderses/xk6-thrift
2025/02/09 18:26:13 INFO Building k6
2025/02/09 18:26:14 INFO Build complete
2025/02/09 18:26:14 INFO Cleaning up work directory /tmp/k6foundry676448791
2025/02/09 18:26:14 INFO Running [./k6 run scripts/get_started.js]


         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: scripts/get_started.js
        output: -

     scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
              * default: 3 iterations shared among 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)

READ 0 Success: request ID <nil>
Response: " Success: request ID "
READ 0 Success: request ID <nil>
Response: " Success: request ID "mplete and 0 interrupted iterations
READ 0 Success: request ID <nil>-----------------] 1 VUs  00m00.1s/10m0s  1/3 sharedResponse: " Success: request ID "

     data_received........: 0 B 0 B/s
     data_sent............: 0 B 0 B/s
     iteration_duration...: avg=36.01ms min=1.57ms med=12.7ms max=93.75ms p(90)=77.54ms p(95)=85.64ms
     iterations...........: 3   27.729919/s


running (00m00.1s), 0/1 VUs, 3 complete and 0 interrupted iterations
default ✓ [===============================] 1 VUs  00m00.1s/10m0s  3/3 shared iters
```

### Server output

```
// omit
18:25:43.147 [armeria-boss-http-*:8080] INFO com.linecorp.armeria.server.Server -- Serving HTTP at /[0:0:0:0:0:0:0:0]:8080 - http://127.0.0.1:8080/
18:26:14.720 [armeria-common-worker-epoll-3-1] INFO com.linecorp.armeria.internal.common.JavaVersionSpecific -- Using the APIs optimized for: Java 12+
18:26:14.745 [armeria-common-worker-epoll-3-1] INFO server.App -- Success: request ID
18:26:14.762 [armeria-common-worker-epoll-3-1] INFO com.linecorp.armeria.logging.access -- 127.0.0.1 - - 09/Feb/2025:18:26:14 +0900 "POST /thrift#TestService$AsyncIface/simpleCall h1c" 200 49
18:26:14.763 [armeria-common-worker-epoll-3-1] INFO server.App -- Success: request ID
18:26:14.764 [armeria-common-worker-epoll-3-1] INFO com.linecorp.armeria.logging.access -- 127.0.0.1 - - 09/Feb/2025:18:26:14 +0900 "POST /thrift#TestService$AsyncIface/simpleCall h1c" 200 49
18:26:14.765 [armeria-common-worker-epoll-3-1] INFO server.App -- Success: request ID
18:26:14.766 [armeria-common-worker-epoll-3-1] INFO com.linecorp.armeria.logging.access -- 127.0.0.1 - - 09/Feb/2025:18:26:14 +0900 "POST /thrift#TestService$AsyncIface/simpleCall h1c" 200 49
```
