### PR TITLE
Add TBool type which represents bool in Thrift

### DIFF
--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -68,3 +68,27 @@ func TestSimpleCall(t *testing.T) {
 		t.Errorf("expected %v, but was %v", expect, actual)
 	}
 }
+
+func TestBoolCall(t *testing.T) {
+	// prepare
+	var client *thrift.TStandardClient
+	var err error
+	if client, err = setupClient(t); err != nil {
+		t.Fatalf("error creating client. %v", err)
+	}
+
+	cxt := context.Background()
+	method := "boolCall"
+	arg := xk6_thrift.NewTBool(true)
+	expect := xk6_thrift.NewTBool(true)
+	actual := xk6_thrift.TBool{}
+
+	// do & verify
+	if _, err = (*client).Call(cxt, method, &arg, &actual); err != nil {
+		t.Fatalf("error calling RPC. %v", err)
+	}
+
+	if actual != expect {
+		t.Errorf("expected %v, but was %v", expect, actual)
+	}
+}

--- a/tbool.go
+++ b/tbool.go
@@ -1,0 +1,116 @@
+package thrift
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type TBool struct {
+	value bool
+}
+
+func NewTBool(v bool) TBool {
+	return TBool{value: v}
+}
+
+func (p *TBool) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 0:
+			if fieldTypeId == thrift.BOOL {
+				if err := p.ReadField0(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		case 1:
+			if fieldTypeId == thrift.BOOL {
+				if err := p.ReadField1(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *TBool) ReadField0(ctx context.Context, iprot thrift.TProtocol) error {
+	v, err := iprot.ReadBool(ctx)
+	fmt.Println("READ 0", v, err)
+	if err != nil {
+		return thrift.PrependError("error reading field 0: ", err)
+	} else {
+		p.value = v
+	}
+	return nil
+}
+
+func (p *TBool) ReadField1(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(ctx); err != nil {
+		return thrift.PrependError("error reading field 1: ", err)
+	} else {
+		p.value = v
+	}
+	return nil
+}
+
+func (p *TBool) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "simple_args"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(ctx, oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *TBool) writeField1(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin(ctx, "id", thrift.BOOL, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:id: ", p), err)
+	}
+	if err := oprot.WriteBool(ctx, p.value); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.id (1) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:id: ", p), err)
+	}
+	return err
+}


### PR DESCRIPTION
# Overview

following.
- https://github.com/lavenderses/xk6-thrift/pull/9

Add `TBool`, for bool in Thrift.

# What's changed

- Implement `TBool` type.
  - this is almost a copy from `TString`.
- Add test to it.
  - calls Thrift service `boolCall`, boolean accepted boolean responded service, added in the above PR.
