### PR TITLE
Change TBool / TString pointer implements TValue

### DIFF
--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -62,7 +62,7 @@ func TestSimpleCall(t *testing.T) {
 	actual := xk6_thrift.NewTResponse()
 
 	// do & verify
-	if _, err = (*client).Call(cxt, method, &arg, actual); err != nil {
+	if _, err = (*client).Call(cxt, method, arg, actual); err != nil {
 		t.Fatalf("error calling RPC. %v", err)
 	}
 
@@ -87,7 +87,7 @@ func TestBoolCall(t *testing.T) {
 	actual := xk6_thrift.NewTResponse()
 
 	// do & verify
-	if _, err = (*client).Call(cxt, method, &arg, actual); err != nil {
+	if _, err = (*client).Call(cxt, method, arg, actual); err != nil {
 		t.Fatalf("error calling RPC. %v", err)
 	}
 

--- a/tbool.go
+++ b/tbool.go
@@ -11,12 +11,12 @@ type TBool struct {
 	value bool
 }
 
-func NewTBool(v bool) TBool {
-	return TBool{value: v}
+func NewTBool(v bool) *TBool {
+	return &TBool{value: v}
 }
 
-func (p TBool) Equals(other *TValue) bool {
-	o, ok := (*other).(TBool)
+func (p *TBool) Equals(other *TValue) bool {
+	o, ok := (*other).(*TBool)
 	if !ok {
 		return false
 	}

--- a/tresponse.go
+++ b/tresponse.go
@@ -57,8 +57,7 @@ func (p *TResponse) ReadString(cxt context.Context, iproto thrift.TProtocol, fie
 		return thrift.PrependError(fmt.Sprintf("error reading string field %d: ", fieldId), err)
 	}
 	
-	tv := NewTstring(v)
-	p.values[fieldId] = tv
+	p.values[fieldId] = NewTstring(v)
 	return nil
 }
 
@@ -68,8 +67,7 @@ func (p *TResponse) ReadBool(cxt context.Context, iproto thrift.TProtocol, field
 		return thrift.PrependError(fmt.Sprintf("error reading boolean field %d: ", fieldId), err)
 	}
 	
-	tv := NewTBool(v)
-	p.values[fieldId] = tv
+	p.values[fieldId] = NewTBool(v)
 	return nil
 }
 

--- a/tstring.go
+++ b/tstring.go
@@ -11,12 +11,12 @@ type TString struct {
 	value string
 }
 
-func NewTstring(v string) TString {
-	return TString{value: v}
+func NewTstring(v string) *TString {
+	return &TString{value: v}
 }
 
-func (p TString) Equals(other *TValue) bool {
-	o, ok := (*other).(TString)
+func (p *TString) Equals(other *TValue) bool {
+	o, ok := (*other).(*TString)
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
# Overview

following.
- https://github.com/lavenderses/xk6-thrift/pull/11

`TBool` / `TString` pointer implements `TValue` instead of its value.

# What's changed

- Changed their pointer (not value) to implement `TValue`.
  - it hasn't unified (to `TStruct` in thrift)
