### PR TITLE
Implement TRequest, generics Thrift request

### DIFF
--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -2,7 +2,6 @@ package it
 
 import (
 	"context"
-	"log/slog"
 	"reflect"
 	"testing"
 
@@ -20,7 +19,7 @@ func setupTransport(t *testing.T) (*thrift.TTransport, error) {
 	}
 	// alaways close transport every test execution
 	t.Cleanup(func() {
-		slog.Info("closing tranport.", slog.Any("transport", trans))
+		t.Logf("closing tranport. %v", trans)
 		trans.Close()
 	})
 
@@ -56,7 +55,9 @@ func TestSimpleCall(t *testing.T) {
 
 	cxt := context.Background()
 	method := "simpleCall"
-	arg := xk6_thrift.NewTstring("ID")
+	values := make(map[int16]xk6_thrift.TValue)
+	values[1] = xk6_thrift.NewTstring("ID")
+	arg := xk6_thrift.NewTRequestWithValue(&values)
 	expect := xk6_thrift.NewTResponse()
 	expect.Add(0, xk6_thrift.NewTstring("Success: ID"))
 	actual := xk6_thrift.NewTResponse()
@@ -81,7 +82,9 @@ func TestBoolCall(t *testing.T) {
 
 	cxt := context.Background()
 	method := "boolCall"
-	arg := xk6_thrift.NewTBool(true)
+	values := make(map[int16]xk6_thrift.TValue)
+	values[1] = xk6_thrift.NewTBool(true)
+	arg := xk6_thrift.NewTRequestWithValue(&values)
 	expect := xk6_thrift.NewTResponse()
 	expect.Add(0, xk6_thrift.NewTBool(true))
 	actual := xk6_thrift.NewTResponse()

--- a/tbool.go
+++ b/tbool.go
@@ -23,6 +23,22 @@ func (p *TBool) Equals(other *TValue) bool {
 	return p.value == o.value
 }
 
+func (p *TBool) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
+	if err = oprot.WriteFieldBegin(cxt, fname, thrift.BOOL, fid); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	if err = oprot.WriteBool(cxt, p.value); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T.id (1) field write error: ", p), err)
+		return
+	}
+	if err = oprot.WriteFieldEnd(cxt); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	return
+}
+
 func (p *TBool) Read(ctx context.Context, iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(ctx); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)

--- a/trequest.go
+++ b/trequest.go
@@ -1,0 +1,66 @@
+package thrift
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type TRequest struct {
+	values map[int16]TValue
+}
+
+func NewTRequest() *TRequest {
+	return &TRequest{values: make(map[int16]TValue)}
+}
+
+func NewTRequestWithValue(v *map[int16]TValue) *TRequest {
+	return &TRequest{values: *v}
+}
+
+func (p *TRequest) Read(cxt context.Context, iprot thrift.TProtocol) (err error) {
+	// dummy
+	return
+}
+
+func (p *TRequest) Write(cxt context.Context, oprot thrift.TProtocol) (err error) {
+	if err = oprot.WriteStructBegin(cxt, "simple_args"); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+		return
+	}
+
+	if err = p.writeFields(cxt, oprot); err != nil {
+		return
+	}
+
+	if err = oprot.WriteFieldStop(cxt); err != nil {
+		err = thrift.PrependError("write field stop error: ", err)
+		return
+	}
+	if err = oprot.WriteStructEnd(cxt); err != nil {
+		err = thrift.PrependError("write struct stop error: ", err)
+		return
+	}
+	return
+}
+
+func (p *TRequest) writeFields(cxt context.Context, oprot thrift.TProtocol) (err error) {
+	if p == nil {
+		return
+	}
+
+	for fid, v := range p.values {
+		if tv, ok := v.(*TString); ok {
+			if err = tv.WriteField(cxt, oprot, fid, "dummy"); err != nil {
+				return
+			}
+		}
+		if tv, ok := v.(*TBool); ok {
+			if err = tv.WriteField(cxt, oprot, fid, "dummy"); err != nil {
+				return
+			}
+		}
+	}
+	return
+}

--- a/tstring.go
+++ b/tstring.go
@@ -23,6 +23,22 @@ func (p *TString) Equals(other *TValue) bool {
 	return p.value == o.value
 }
 
+func (p *TString) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
+	if err = oprot.WriteFieldBegin(cxt, fname, thrift.STRING, fid); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	if err = oprot.WriteString(cxt, string(p.value)); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T.id (1) field write error: ", p), err)
+		return
+	}
+	if err = oprot.WriteFieldEnd(cxt); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	return
+}
+
 func (p *TString) Read(ctx context.Context, iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(ctx); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)

--- a/tvalue.go
+++ b/tvalue.go
@@ -1,5 +1,14 @@
 package thrift
 
+import (
+	"context"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
 type TValue interface {
 	Equals(other *TValue) bool
+	// WriteField outputs TValue to Thrift protocol with field ID `fid` and field name `fname`.
+	// This must start with `WriteFieldBegin` method call, and end with `WriteFieldEnd` method call.
+	WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) error
 }


### PR DESCRIPTION
# Overview

similar.
- https://github.com/lavenderses/xk6-thrift/pull/11

A generics Thrift response representation is introduced.

# What's changed

- Introduce `TRequest`, a generics representation for Thrift request.
- Use it in test.

## `TRequest` notation

### `Read` method is not implemented

`TRequest` will be used only in Thrift request. So it's unecessary for it to read field and construct it.

### Fields in it might change

Currently `TRequest` has simle `values map[int16]TValue` field, which key is field ID in Thrift. This is same as `TResponse`.
But also field name is needed. This will be occured when implementing following first TODO.
And also want to re-consider structure of `Trequest`.

## TODOs

- [ ] Write fields with validation.
  - Use JSON schema definition. See [server/thrift/build/generated-sources/thrift/gen-json/idl.json @ ce537cf](https://github.com/lavenderses/xk6-thrift/blob/ce537cff2f8ca92fe823182ca25054555d0a9437/server/thrift/build/generated-sources/thrift/gen-json/idl.json)
- [x] Unused method cleanup.
  - `Read` / `Write` method in `TString` / `TBool` is unused anymore.
  - https://github.com/lavenderses/xk6-thrift/pull/16
