### PR TITLE
Add TMap type which represents map in Thrift

### DIFF
--- a/it/assertion.go
+++ b/it/assertion.go
@@ -1,0 +1,40 @@
+package it
+
+import (
+	"fmt"
+	"testing"
+
+	xk6_thrift "github.com/lavenderses/xk6-thrift"
+)
+
+func assertEquals(t *testing.T, actual, expect xk6_thrift.TResponse) {
+	t.Logf("Got: %v, expected: %v", actual, expect)
+	avs := *actual.Values()
+	evs := *expect.Values()
+	if len(avs) != len(evs) {
+		msg := fmt.Sprintf("expeted size %d, but was %d", len(evs), len(avs))
+		t.Errorf(msg)
+		return
+	}
+
+	failure := false
+	msg := "[FAILED]"
+	for ek, ev := range evs {
+		av := avs[ek]
+		if !av.Equals(&ev) {
+			msg = fmt.Sprintf("%s\nexpected %v, but was %v", msg, ev, av)
+			failure = true
+		}
+	}
+	for ak, av := range evs {
+		ev := evs[ak]
+		if ev == nil {
+			msg = fmt.Sprintf("%s\ngo unexpected value %v", msg, av)
+			failure = true
+		}
+	}
+
+	if failure {
+		t.Error(msg)
+	}
+}

--- a/tbool.go
+++ b/tbool.go
@@ -11,19 +11,19 @@ type TBool struct {
 	value bool
 }
 
-func NewTBool(v bool) *TBool {
-	return &TBool{value: v}
+func NewTBool(v bool) TBool {
+	return TBool{value: v}
 }
 
-func (p *TBool) Equals(other *TValue) bool {
-	o, ok := (*other).(*TBool)
+func (p TBool) Equals(other *TValue) bool {
+	o, ok := (*other).(TBool)
 	if !ok {
 		return false
 	}
 	return p.value == o.value
 }
 
-func (p *TBool) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
+func (p TBool) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
 	if err = oprot.WriteFieldBegin(cxt, fname, thrift.BOOL, fid); err != nil {
 		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
 		return
@@ -39,6 +39,7 @@ func (p *TBool) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int1
 	return
 }
 
+// following methods will be removed
 func (p *TBool) Read(ctx context.Context, iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(ctx); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)

--- a/trequest.go
+++ b/trequest.go
@@ -51,15 +51,8 @@ func (p *TRequest) writeFields(cxt context.Context, oprot thrift.TProtocol) (err
 	}
 
 	for fid, v := range p.values {
-		if tv, ok := v.(*TString); ok {
-			if err = tv.WriteField(cxt, oprot, fid, "dummy"); err != nil {
-				return
-			}
-		}
-		if tv, ok := v.(*TBool); ok {
-			if err = tv.WriteField(cxt, oprot, fid, "dummy"); err != nil {
-				return
-			}
+		if err = v.WriteField(cxt, oprot, fid, "dummy"); err != nil {
+			return
 		}
 	}
 	return

--- a/tstring.go
+++ b/tstring.go
@@ -11,19 +11,19 @@ type TString struct {
 	value string
 }
 
-func NewTstring(v string) *TString {
-	return &TString{value: v}
+func NewTstring(v string) TString {
+	return TString{value: v}
 }
 
-func (p *TString) Equals(other *TValue) bool {
-	o, ok := (*other).(*TString)
+func (p TString) Equals(other *TValue) bool {
+	o, ok := (*other).(TString)
 	if !ok {
 		return false
 	}
 	return p.value == o.value
 }
 
-func (p *TString) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
+func (p TString) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
 	if err = oprot.WriteFieldBegin(cxt, fname, thrift.STRING, fid); err != nil {
 		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
 		return
@@ -39,6 +39,7 @@ func (p *TString) WriteField(cxt context.Context, oprot thrift.TProtocol, fid in
 	return
 }
 
+// following methods will be removed
 func (p *TString) Read(ctx context.Context, iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(ctx); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)


### PR DESCRIPTION
# Overview

following.
- https://github.com/lavenderses/xk6-thrift/pull/14

Add `TMap`, for map in Thrift.

# What's changed (important)

- Change `TString` / `TValue` implement `TValue` (generic interface for Thrift types such as string, bool), not their pointers.
- Implement `TMap`
  - `*TMap` implements `TValue` interface
- Don't switch to call `WriteField` in `TRequest`
  - because `v` (each value in `TRequest.values`) implements `TValue`. and `TValue` itself has method `WriteField`.
  - no needed to to do it.
- Add custom assertion for `TResponse`, `assertEquals`.

## Why values implement `Tvalue`, not their pointers

Because it is used as map key in `TMap`.
If implemented `TValue` is a pointer, it doesn't work (because it's pointer).
`TString` and `TBool` is just a tiny wrapper of primitives (string and bool), so I think it doesn't have high effect to memory.

## Why `*TMap` implements `TValue`, not the value

Because it is a wrapper of `map<>`. Memory cost might be high to copy.
(I think requesting such a huge object will be occured in few case.)

Container type (following ref) will be implemented like this in the future. (And also struct).

> Thrift containers are strongly typed containers that map to commonly used and commonly available container types in most programming languages.
> https://thrift.apache.org/docs/types#containers

# TODOs

- [x] Remove `Read` and `Write` method in each implementation of `TValue`
  - because it's not neecssary to implement `TStruct`. `TRequest` and `TResponse` already implemet it.
  - `TMap` does not implements it from first time.
  - https://github.com/lavenderses/xk6-thrift/pull/16
