### PR TITLE
Brush up exmple script to use xk6-thrift

### DIFF
--- a/scripts/get_started.js
+++ b/scripts/get_started.js
@@ -1,10 +1,16 @@
 import thrift from 'k6/x/thrift';
+import ttypes from 'k6/x/thrift/ttypes';
 
 export const options = {
   vus: 1,
-  iterations: 3,
+  iterations: 1,
 }
 
 export default function() {
-  thrift.echo();
+  const method = "simpleCall";
+  const values = {};
+  values[1] = ttypes.newTString("ID");
+  const req = ttypes.newTRequest(values);
+
+  thrift.call(method, req);
 }

--- a/thrift.go
+++ b/thrift.go
@@ -11,7 +11,8 @@ import (
 )
 
 func init() {
-	modules.Register("k6/x/thrift", &TModule{})
+	modules.Register("k6/x/thrift", new(TModule))
+	modules.Register("k6/x/thrift/ttypes", new(TTypes))
 }
 
 type TModule struct{}
@@ -49,6 +50,43 @@ func (m *TModule) Echo() {
 	values := make(map[int16]TValue)
 	values[1] = NewTstring("ID")
 	req := NewTRequestWithValue(&values)
+	res := NewTResponse()
+
+	cxt := context.Background()
+	tclient.Call(cxt, method, req, res)
+
+	slog.Info("Response:", res.values)
+}
+
+func (m *TModule) Call(method string, req *TRequest) {
+	host := "127.0.0.1"
+	port := 8080
+	path := "/thrift"
+
+	tf := thrift.NewTHttpClientTransportFactory("http://" + host + ":" + strconv.Itoa(port) + path)
+	cfg := thrift.TConfiguration{
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	sock := thrift.NewTSocketConf("127.0.0.1:8080", &cfg)
+	transport, err := tf.GetTransport(sock)
+	if err != nil {
+		slog.Error("ERROR: ", err)
+		return
+	}
+	pf := thrift.NewTBinaryProtocolFactoryConf(&cfg)
+	iprot := pf.GetProtocol(transport)
+	oprot := pf.GetProtocol(transport)
+	tclient := thrift.NewTStandardClient(iprot, oprot)
+	defer transport.Close()
+
+	err = transport.Open()
+	if err != nil {
+		slog.Error("ERROR: ", err)
+		return
+	}
+
 	res := NewTResponse()
 
 	cxt := context.Background()

--- a/types.go
+++ b/types.go
@@ -1,0 +1,11 @@
+package thrift
+
+type TTypes struct {}
+
+func (*TTypes) NewTString(v string) TString {
+	return NewTstring(v)
+}
+
+func (*TTypes) NewTRequest(v *map[int16]TValue) *TRequest {
+	return NewTRequestWithValue(v)
+}


### PR DESCRIPTION
# Overview

Update example script to run xk6-thrift.

# What's changed

- Update scripts/get_started.js  to call `simpleCall` Thrift RPC with `TRequest`.

This is the example output.

```console
$ xk6 run scripts/get_started.js

2025/02/20 22:32:06 INFO Building k6
2025/02/20 22:32:06 INFO Building new k6 binary (native)
2025/02/20 22:32:06 INFO Initializing Go module
go: creating new go.mod: module k6
2025/02/20 22:32:06 INFO replacing dependency github.com/lavenderses/xk6-thrift => /home/nakanoi/projects/xk6-thrift
2025/02/20 22:32:06 INFO Creating k6 main
2025/02/20 22:32:06 INFO adding dependency go.k6.io/k6@latest
go: finding module for package github.com/fsnotify/fsnotify
go: finding module for package gopkg.in/tomb.v1
go: found gopkg.in/tomb.v1 in gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: found github.com/fsnotify/fsnotify in github.com/fsnotify/fsnotify v1.8.0
2025/02/20 22:32:07 INFO importing extensions
2025/02/20 22:32:07 INFO adding dependency github.com/lavenderses/xk6-thrift
2025/02/20 22:32:12 INFO Building k6
2025/02/20 22:32:15 INFO Build complete
2025/02/20 22:32:15 INFO Cleaning up work directory /tmp/k6foundry513046859
2025/02/20 22:32:15 INFO Running [./k6 run scripts/get_started.js]


         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: scripts/get_started.js
        output: -

     scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
              * default: 1 iterations shared among 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)

INFO[0000] 2025/02/20 22:32:15 INFO Response: !BADKEY="map[0:{value:Success: ID}]" 

     data_received........: 0 B 0 B/s
     data_sent............: 0 B 0 B/s
     iteration_duration...: avg=178.85ms min=178.85ms med=178.85ms max=178.85ms p(90)=178.85ms p(95)=178.85ms
     iterations...........: 1   5.586753/s


running (00m00.2s), 0/1 VUs, 1 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  00m00.2s/10m0s  1/1 shared iters
```