### PR TITLE
Add TStruct type which represents struct in Thrift

### DIFF
--- a/it/assertion.go
+++ b/it/assertion.go
@@ -26,7 +26,7 @@ func assertEquals(t *testing.T, actual, expect xk6_thrift.TResponse) {
 			failure = true
 		}
 	}
-	for ak, av := range evs {
+	for ak, av := range avs {
 		ev := evs[ak]
 		if ev == nil {
 			msg = fmt.Sprintf("%s\ngo unexpected value %v", msg, av)

--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -141,7 +141,7 @@ func TestMessageCall(t *testing.T) {
 		*xk6_thrift.NewTStructField(1, "content"): xk6_thrift.NewTstring("this is a content"),
 		*xk6_thrift.NewTStructField(2, "tags"): xk6_thrift.NewTMap(
 			&map[xk6_thrift.TValue]xk6_thrift.TValue{
-				xk6_thrift.NewTstring("bool true"): xk6_thrift.NewTBool(true),
+				xk6_thrift.NewTstring("bool true"):  xk6_thrift.NewTBool(true),
 				xk6_thrift.NewTstring("bool false"): xk6_thrift.NewTBool(false),
 			},
 		),
@@ -156,16 +156,16 @@ func TestMessageCall(t *testing.T) {
 	}
 	arg := xk6_thrift.NewTRequestWithValue(&tvalue)
 	expectValue := map[xk6_thrift.TStructField]xk6_thrift.TValue{
-		*xk6_thrift.NewTStructField(1, "content"): xk6_thrift.NewTstring("this is a content"),
-		*xk6_thrift.NewTStructField(2, "tags"): xk6_thrift.NewTMap(
+		*xk6_thrift.NewTStructField(1, ""): xk6_thrift.NewTstring("content: this is a content"),
+		*xk6_thrift.NewTStructField(2, ""): xk6_thrift.NewTMap(
 			&map[xk6_thrift.TValue]xk6_thrift.TValue{
-				xk6_thrift.NewTstring("bool true"): xk6_thrift.NewTBool(true),
+				xk6_thrift.NewTstring("bool true"):  xk6_thrift.NewTBool(true),
 				xk6_thrift.NewTstring("bool false"): xk6_thrift.NewTBool(false),
 			},
 		),
-		*xk6_thrift.NewTStructField(3, "nested"): xk6_thrift.NewTStruct(
+		*xk6_thrift.NewTStructField(3, ""): xk6_thrift.NewTStruct(
 			&map[xk6_thrift.TStructField]xk6_thrift.TValue{
-				*xk6_thrift.NewTStructField(1, "inner"): xk6_thrift.NewTstring("this is an inner content"),
+				*xk6_thrift.NewTStructField(1, ""): xk6_thrift.NewTstring("this is an inner content"),
 			},
 		),
 	}

--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -126,3 +126,58 @@ func TestMapCall(t *testing.T) {
 
 	assertEquals(t, *actual, *expect)
 }
+
+func TestMessageCall(t *testing.T) {
+	// prepare
+	var client *thrift.TStandardClient
+	var err error
+	if client, err = setupClient(t); err != nil {
+		t.Fatalf("error creating client. %v", err)
+	}
+
+	cxt := context.Background()
+	method := "messageCall"
+	value := map[xk6_thrift.TStructField]xk6_thrift.TValue{
+		*xk6_thrift.NewTStructField(1, "content"): xk6_thrift.NewTstring("this is a content"),
+		*xk6_thrift.NewTStructField(2, "tags"): xk6_thrift.NewTMap(
+			&map[xk6_thrift.TValue]xk6_thrift.TValue{
+				xk6_thrift.NewTstring("bool true"): xk6_thrift.NewTBool(true),
+				xk6_thrift.NewTstring("bool false"): xk6_thrift.NewTBool(false),
+			},
+		),
+		*xk6_thrift.NewTStructField(3, "nested"): xk6_thrift.NewTStruct(
+			&map[xk6_thrift.TStructField]xk6_thrift.TValue{
+				*xk6_thrift.NewTStructField(1, "inner"): xk6_thrift.NewTstring("this is an inner content"),
+			},
+		),
+	}
+	tvalue := map[int16]xk6_thrift.TValue{
+		1: xk6_thrift.NewTStruct(&value),
+	}
+	arg := xk6_thrift.NewTRequestWithValue(&tvalue)
+	expectValue := map[xk6_thrift.TStructField]xk6_thrift.TValue{
+		*xk6_thrift.NewTStructField(1, "content"): xk6_thrift.NewTstring("this is a content"),
+		*xk6_thrift.NewTStructField(2, "tags"): xk6_thrift.NewTMap(
+			&map[xk6_thrift.TValue]xk6_thrift.TValue{
+				xk6_thrift.NewTstring("bool true"): xk6_thrift.NewTBool(true),
+				xk6_thrift.NewTstring("bool false"): xk6_thrift.NewTBool(false),
+			},
+		),
+		*xk6_thrift.NewTStructField(3, "nested"): xk6_thrift.NewTStruct(
+			&map[xk6_thrift.TStructField]xk6_thrift.TValue{
+				*xk6_thrift.NewTStructField(1, "inner"): xk6_thrift.NewTstring("this is an inner content"),
+			},
+		),
+	}
+	expectTValue := xk6_thrift.NewTStruct(&expectValue)
+	expect := xk6_thrift.NewTResponse()
+	expect.Add(0, expectTValue)
+	actual := xk6_thrift.NewTResponse()
+
+	// do & verify
+	if _, err = (*client).Call(cxt, method, arg, actual); err != nil {
+		t.Fatalf("error calling RPC. %v", err)
+	}
+
+	assertEquals(t, *actual, *expect)
+}

--- a/tstruct.go
+++ b/tstruct.go
@@ -46,6 +46,14 @@ func (p *TStruct) Equals(other *TValue) bool {
 	return true
 }
 
+// see [Thrift protocol spec @ 1a31d90 (v0.21.0)].
+//
+// [Thrift protocol spec @ 1a31d90 (v0.21.0)]: https://github.com/apache/thrift/blob/1a31d9051d35b732a5fce258955ef95f576694ba/doc/specs/thrift-protocol-spec.md (v0.21.0)
+// 
+// 	<field> ::= <field-begin> <field-data> <field-end>
+// 		<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+// 	<struct> | <map> | <list> | <set>
+// 	<struct> ::= <struct-begin> <field>* <field-stop> <struct-end>
 func (p *TStruct) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
 	if err = oprot.WriteFieldBegin(cxt, fname, thrift.STRUCT, fid); err != nil {
 		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
@@ -58,7 +66,7 @@ func (p *TStruct) WriteField(cxt context.Context, oprot thrift.TProtocol, fid in
 	// write struct fields recursively
 	for _, f := range slices.SortedFunc(maps.Keys(p.value), func(a, b TStructField) int {
 		return int(a.id) - int(b.id)
-	}){
+	}) {
 		p.value[f].WriteField(cxt, oprot, f.id, f.name)
 	}
 

--- a/tstruct.go
+++ b/tstruct.go
@@ -48,12 +48,12 @@ func (p *TStruct) Equals(other *TValue) bool {
 
 // see [Thrift protocol spec @ 1a31d90 (v0.21.0)].
 //
+//	<field> ::= <field-begin> <field-data> <field-end>
+//		<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+//	<struct> | <map> | <list> | <set>
+//	<struct> ::= <struct-begin> <field>* <field-stop> <struct-end>
+//
 // [Thrift protocol spec @ 1a31d90 (v0.21.0)]: https://github.com/apache/thrift/blob/1a31d9051d35b732a5fce258955ef95f576694ba/doc/specs/thrift-protocol-spec.md (v0.21.0)
-// 
-// 	<field> ::= <field-begin> <field-data> <field-end>
-// 		<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
-// 	<struct> | <map> | <list> | <set>
-// 	<struct> ::= <struct-begin> <field>* <field-stop> <struct-end>
 func (p *TStruct) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
 	if err = oprot.WriteFieldBegin(cxt, fname, thrift.STRUCT, fid); err != nil {
 		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)

--- a/tstruct.go
+++ b/tstruct.go
@@ -1,0 +1,76 @@
+package thrift
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type TStructField struct {
+	id   int16
+	name string
+}
+
+type TStruct struct {
+	value map[TStructField]TValue
+}
+
+func NewTStructField(id int16, name string) *TStructField {
+	return &TStructField{id: id, name: name}
+}
+
+func NewTStruct(value *map[TStructField]TValue) *TStruct {
+	return &TStruct{value: *value}
+}
+
+func (p *TStruct) Equals(other *TValue) bool {
+	o, ok := (*other).(*TStruct)
+	if !ok {
+		return false
+	}
+
+	if len(p.value) != len(o.value) {
+		return false
+	}
+
+	for pk, pv := range p.value {
+		ov := o.value[pk]
+		if !pv.Equals(&ov) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (p *TStruct) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
+	if err = oprot.WriteFieldBegin(cxt, fname, thrift.STRUCT, fid); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	if err = oprot.WriteStructBegin(cxt, fname); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) begin error: ", p, fid, fname), err)
+	}
+
+	// write struct fields recursively
+	for _, f := range slices.SortedFunc(maps.Keys(p.value), func(a, b TStructField) int {
+		return int(a.id) - int(b.id)
+	}){
+		p.value[f].WriteField(cxt, oprot, f.id, f.name)
+	}
+
+	if err = oprot.WriteFieldStop(cxt); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) stop error: ", p, fid, fname), err)
+	}
+	if err = oprot.WriteStructEnd(cxt); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) end error: ", p, fid, fname), err)
+	}
+	if err = oprot.WriteFieldEnd(cxt); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	return
+}


### PR DESCRIPTION
# Overview

following.
- https://github.com/lavenderses/xk6-thrift/pull/14

Introduce struct support.

# What's changed

- Implement `TStruct`
  - simliar to `TMap`
  - `*TStruct` implements `TValue`
- Add test using `TStruct`

## How does it works

struct in Thrift is just a list of (field ID, field value) pair in protocol.
```go
//	<field> ::= <field-begin> <field-data> <field-end>
//		<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
//	<struct> | <map> | <list> | <set>
//	<struct> ::= <struct-begin> <field>* <field-stop> <struct-end>
//
// [Thrift protocol spec @ 1a31d90 (v0.21.0)]: https://github.com/apache/thrift/blob/1a31d9051d35b732a5fce258955ef95f576694ba/doc/specs/thrift-protocol-spec.md (v0.21.0)
```

So, read / write of `TStruct` just should call other `TValue`' s read method for itself or `WriteField` method.

read.
https://github.com/lavenderses/xk6-thrift/blob/2b5a258cf3247ec50c71ba10ed9670ef8ad0c811/tresponse.go#L42-L51

write.
https://github.com/lavenderses/xk6-thrift/blob/2b5a258cf3247ec50c71ba10ed9670ef8ad0c811/tstruct.go#L66-L71

## Struct field name

Somehow field name retrived by `iprot.ReadFieldBegin()` is empty.
It doesn't have any bad effect because the matter in protocol is field ID, not field name.

https://github.com/lavenderses/xk6-thrift/blob/2b5a258cf3247ec50c71ba10ed9670ef8ad0c811/tresponse.go#L174-L175

But assersion looks strange. And it's not easy to understand.
https://github.com/lavenderses/xk6-thrift/blob/2b5a258cf3247ec50c71ba10ed9670ef8ad0c811/it/test_service_test.go#L158-L172
So this issue will be fixed in future other PR.

## TODOs

- [ ] use field name
