### PR TITLE
Introduce k6 check for Thrift RPC response

### DIFF
--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -68,6 +68,29 @@ func TestSimpleCall(t *testing.T) {
 	assertEquals(t, *actual, *expect)
 }
 
+func TestSimpleCallFailure(t *testing.T) {
+	// prepare
+	var client *thrift.TStandardClient
+	var err error
+	if client, err = setupClient(t); err != nil {
+		t.Fatalf("error creating client. %v", err)
+	}
+
+	cxt := context.Background()
+	method := "simpleCall"
+	values := make(map[int16]xk6_thrift.TValue)
+	values[1] = xk6_thrift.NewTstring("FAILURE")
+	arg := xk6_thrift.NewTRequestWithValue(&values)
+	expect := xk6_thrift.NewTResponse()
+	expect.Add(0, xk6_thrift.NewTstring("Success: ID"))
+	actual := xk6_thrift.NewTResponse()
+
+	// do & verify
+	if _, err = (*client).Call(cxt, method, arg, actual); err == nil {
+		t.Fatalf("error NOT THROWN calling RPC. %v", err)
+	}
+}
+
 func TestBoolCall(t *testing.T) {
 	// prepare
 	var client *thrift.TStandardClient

--- a/tcall_result.go
+++ b/tcall_result.go
@@ -1,0 +1,21 @@
+package thrift
+
+type TCallResult struct {
+	body TValue
+	err error
+}
+
+func NewTCallResult(body *TValue, err error) *TCallResult {
+	switch {
+	case body == nil:
+		return &TCallResult{body: nil, err: err}
+	case err != nil:
+		return &TCallResult{body: nil, err: err}
+	default:
+		return &TCallResult{body: *body, err: err}
+	}
+}
+
+func (r *TCallResult) IsSuccess() bool {
+	return r.err == nil
+}

--- a/thrift.go
+++ b/thrift.go
@@ -112,7 +112,7 @@ func (m *TModule) Call(method string, req *TRequest) *TCallResult {
 		return NewTCallResult(nil, fmt.Errorf("Empty body"))
 	}
 
-	slog.Info("Response:", res.values)
+	slog.Info(fmt.Sprintf("Response: %v", res.values))
 	
 	return NewTCallResult(&body, nil)
 }

--- a/thrift.go
+++ b/thrift.go
@@ -33,7 +33,7 @@ func (m *TModule) Echo() *TCallResult {
 	sock := thrift.NewTSocketConf("127.0.0.1:8080", &cfg)
 	transport, err := tf.GetTransport(sock)
 	if err != nil {
-		slog.Error("ERROR while getting transport", slog.Any("error", err))
+		slog.Error(fmt.Sprintf("ERROR while getting transport: %v", err))
 		return NewTCallResult(nil, err)
 	}
 	pf := thrift.NewTBinaryProtocolFactoryConf(&cfg)
@@ -44,7 +44,7 @@ func (m *TModule) Echo() *TCallResult {
 
 	err = transport.Open()
 	if err != nil {
-		slog.Error("ERROR while opening transport", slog.Any("error", err))
+		slog.Error(fmt.Sprintf("ERROR while opening transport: %v", err))
 		return NewTCallResult(nil, err)
 	}
 
@@ -56,7 +56,7 @@ func (m *TModule) Echo() *TCallResult {
 	cxt := context.Background()
 	_, err = tclient.Call(cxt, method, req, res)
 	if err != nil {
-		slog.Error("ERROR calling RPC", slog.Any("error", err))
+		slog.Error(fmt.Sprintf("ERROR calling RPC: %v", err))
 		return NewTCallResult(nil, err)
 	}
 
@@ -84,7 +84,7 @@ func (m *TModule) Call(method string, req *TRequest) *TCallResult {
 	sock := thrift.NewTSocketConf("127.0.0.1:8080", &cfg)
 	transport, err := tf.GetTransport(sock)
 	if err != nil {
-		slog.Error("ERROR: ", err)
+		slog.Error(fmt.Sprintf("ERROR: %v", err))
 		return NewTCallResult(nil, err)
 	}
 	pf := thrift.NewTBinaryProtocolFactoryConf(&cfg)
@@ -95,7 +95,7 @@ func (m *TModule) Call(method string, req *TRequest) *TCallResult {
 
 	err = transport.Open()
 	if err != nil {
-		slog.Error("ERROR: ", err)
+		slog.Error(fmt.Sprintf("ERROR: %v", err))
 		return NewTCallResult(nil, err)
 	}
 
@@ -104,7 +104,7 @@ func (m *TModule) Call(method string, req *TRequest) *TCallResult {
 	cxt := context.Background()
 	_, err = tclient.Call(cxt, method, req, res)
 	if err != nil {
-		slog.Error("ERROR calling RPC", slog.Any("error", err))
+		slog.Error(fmt.Sprintf("ERROR calling RPC: %v", err))
 		return NewTCallResult(nil, err)
 	}
 	body := res.values[0]


### PR DESCRIPTION
# Overview

k6 check ([Checks \| Grafana k6 documentation](https://grafana.com/docs/k6/latest/using-k6/checks/)) is here for Thrift k6.

# What's changed

- Introduce `TCallResult`, which represents Thrift RPC response result.
  - Currently, it only contains a boolean representing whether the result is successful.
- Respond `TCallResult` in `TModule.Call` method.

## TODOs

- [ ] Use this result check in the test script / README.
