### PR TITLE
Implement Thrift type list

### DIFF
--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -204,3 +204,38 @@ func TestMessageCall(t *testing.T) {
 
 	assertEquals(t, *actual, *expect)
 }
+
+func TestStringCall(t *testing.T) {
+	// prepare
+	var client *thrift.TStandardClient
+	var err error
+	if client, err = setupClient(t); err != nil {
+		t.Fatalf("error creating client. %v", err)
+	}
+
+	cxt := context.Background()
+	method := "stringCall"
+	value := []xk6_thrift.TValue{
+		xk6_thrift.NewTstring("content-1"),
+		xk6_thrift.NewTstring("content-2"),
+	}
+	tvalue := map[int16]xk6_thrift.TValue{
+		1: xk6_thrift.NewTList(&value, thrift.STRING),
+	}
+	arg := xk6_thrift.NewTRequestWithValue(&tvalue)
+	expectValue := []xk6_thrift.TValue{
+		xk6_thrift.NewTstring("content-1:content-1"),
+		xk6_thrift.NewTstring("content-2:content-2"),
+	}
+	expectTValue := xk6_thrift.NewTList(&expectValue, thrift.STRING)
+	expect := xk6_thrift.NewTResponse()
+	expect.Add(0, expectTValue)
+	actual := xk6_thrift.NewTResponse()
+
+	// do & verify
+	if _, err = (*client).Call(cxt, method, arg, actual); err != nil {
+		t.Fatalf("error calling RPC. %v", err)
+	}
+
+	assertEquals(t, *actual, *expect)
+}

--- a/tlist.go
+++ b/tlist.go
@@ -1,0 +1,94 @@
+package thrift
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type TList struct {
+	value     []TValue
+	valueType thrift.TType
+}
+
+func NewTList(v *[]TValue, valueType thrift.TType) *TList {
+	return &TList{value: *v, valueType: valueType}
+}
+
+func (p *TList) Equals(other *TValue) bool {
+	o, ok := (*other).(*TList)
+	if !ok {
+		return false
+	}
+	if len(p.value) != len(o.value) {
+		return false
+	}
+	for pk, pv := range p.value {
+		ov := o.value[pk]
+		if !pv.Equals(&ov) {
+			return false
+		}
+	}
+	return true
+}
+
+// See [Thrift IDL protocol spec]
+//
+//		<field>          ::= <field-begin> <list> <field-end>
+//		<list>           ::= <list-begin> <field-data>* <list-end>
+//	     <list-begin>     ::= <list-elem-type> <list-size>
+//	     <list-elem-type> ::= <field-type>
+//	     <list-size>      ::= I32
+//		<field-data>     ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+//		                 <struct> | <map> | <list> | <set>
+//
+// [Thrift IDL protocol spec]: https://github.com/apache/thrift/blob/eec0b584e657e4250e22f3fd492858d632e2aa7b/doc/specs/thrift-protocol-spec.md
+func (p *TList) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
+	if err = oprot.WriteFieldBegin(cxt, fname, thrift.LIST, fid); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	if err = oprot.WriteListBegin(cxt, p.valueType, len(p.value)); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write list begin error %d:%s", p, fid, fname), err)
+		return
+	}
+
+	for _, v := range p.value {
+		// if err = v.WriteField(cxt, oprot, fid, fname); err != nil {
+		// 	err = thrift.PrependError(fmt.Sprintf("%T write list field data (field %d) error", p, fid), err)
+		// 	return
+		// }
+		if err = p.writeFieldData(cxt, oprot, v, fid, fname); err != nil {
+			err = thrift.PrependError(fmt.Sprintf("%T write list field data (field %d) error", p, fid), err)
+			return
+		}
+	}
+
+	if err = oprot.WriteListEnd(cxt); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write list end error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	if err = oprot.WriteFieldEnd(cxt); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
+		return
+	}
+	return
+}
+
+// See the above spec.
+//
+//	<field-data>     ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+//	                 <struct> | <map> | <list> | <set>
+func (p *TList) writeFieldData(cxt context.Context, oprot thrift.TProtocol, value TValue, fid int16, fname string) (err error) {
+	if o, ok := value.(TString); ok {
+		err = oprot.WriteString(cxt, o.value)
+	} else if o, ok := value.(TBool); ok {
+		err = oprot.WriteBool(cxt, o.value)
+	} else if o, ok := value.(*TMap); ok {
+		err = o.WriteField(cxt, oprot, fid, fname)
+	} else if o, ok := value.(*TStruct); ok {
+		err = o.WriteField(cxt, oprot, fid, fname)
+	}
+	return
+}

--- a/tresponse.go
+++ b/tresponse.go
@@ -44,6 +44,8 @@ func (p *TResponse) Read(cxt context.Context, iprot thrift.TProtocol) error {
 				v, err = p.ReadString(cxt, iprot, fieldId)
 			case thrift.BOOL:
 				v, err = p.ReadBool(cxt, iprot, fieldId)
+			case thrift.LIST:
+				v, err = p.ReadList(cxt, iprot, fieldId)
 			case thrift.MAP:
 				v, err = p.ReadMap(cxt, iprot, fieldId)
 			case thrift.STRUCT:
@@ -114,6 +116,45 @@ func (p *TResponse) readFeidlDataList(cxt context.Context, iprot thrift.TProtoco
 }
 
 func (p *TResponse) readField(cxt context.Context, iprot thrift.TProtocol, ttype thrift.TType) (tv TValue, err error) {
+	switch ttype {
+	case thrift.STRING:
+		if v, err := iprot.ReadString(cxt); err != nil {
+			return nil, err
+		} else {
+			tv = NewTstring(v)
+		}
+	case thrift.BOOL:
+		if v, err := iprot.ReadBool(cxt); err != nil {
+			return nil, err
+		} else {
+			tv = NewTBool(v)
+		}
+	}
+
+	return
+}
+
+func (p *TResponse) ReadList(cxt context.Context, iproto thrift.TProtocol, fieldId int16) (*TList, error) {
+	valueType, size, err := iproto.ReadListBegin(cxt)
+	if err != nil {
+		return nil, thrift.PrependError(fmt.Sprintf("error reading list field %d: ", fieldId), err)
+	}
+
+	var tlist []TValue
+	for i := 0; i < size; i++ {
+		var tv TValue
+		tv, err = p.readListField(cxt, iproto, valueType)
+		if err != nil {
+			return nil, thrift.PrependError(fmt.Sprintf("error reading list %d: ", fieldId), err)
+		}
+		tlist = append(tlist, tv)
+	}
+
+	res := NewTList(&tlist, valueType)
+	return res, nil
+}
+
+func (p *TResponse) readListField(cxt context.Context, iprot thrift.TProtocol, ttype thrift.TType) (tv TValue, err error) {
 	switch ttype {
 	case thrift.STRING:
 		if v, err := iprot.ReadString(cxt); err != nil {


### PR DESCRIPTION
# Overview

Introduced a new type of support for list in Thrift.

# What's changed

- Add `TList`, which represents list type in Thrift.
  - Like `TMap`.
- Use it in the integration test.
  - Calls `stringCall()`, which accepts and responses `list<string>`.

## TODOs

- [ ] Support list contains non-primitive types such as list and struct.
  May require refactoring in read / write methods of `TValue`.