### PR TITLE
Refactor Thrfit field data write metod

### DIFF
--- a/tbool.go
+++ b/tbool.go
@@ -25,22 +25,18 @@ func (p TBool) Equals(other *TValue) bool {
 
 // See [Thrift IDL protocol spec]
 //
-//   <field> ::= <field-begin> <field-data> <field-end>
-//   <field-data> ::= BOOL
+//	<field> ::= <field-begin> <field-data> <field-end>
+//	<field-data> ::= BOOL
 //
 // [Thrift IDL protocol spec]: https://github.com/apache/thrift/blob/eec0b584e657e4250e22f3fd492858d632e2aa7b/doc/specs/thrift-protocol-spec.md
-func (p TBool) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
-	if err = oprot.WriteFieldBegin(cxt, fname, thrift.BOOL, fid); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
-		return
-	}
+func (p TBool) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err error) {
 	if err = oprot.WriteBool(cxt, p.value); err != nil {
 		err = thrift.PrependError(fmt.Sprintf("%T.id (1) field write error: ", p), err)
 		return
 	}
-	if err = oprot.WriteFieldEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
-		return
-	}
 	return
+}
+
+func (p TBool) TType() thrift.TType {
+	return thrift.BOOL
 }

--- a/tlist.go
+++ b/tlist.go
@@ -55,6 +55,7 @@ func (p *TList) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err
 		//			<struct> | <map> | <list> | <set>
 		if err = v.WriteFieldData(cxt, oprot); err != nil {
 			err = thrift.PrependError(fmt.Sprintf("%T write list field data error", p), err)
+			return
 		}
 	}
 

--- a/tlist.go
+++ b/tlist.go
@@ -51,36 +51,16 @@ func (p *TList) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err
 	}
 
 	for _, v := range p.value {
-		// if err = v.WriteField(cxt, oprot, fid, fname); err != nil {
-		// 	err = thrift.PrependError(fmt.Sprintf("%T write list field data (field %d) error", p, fid), err)
-		// 	return
-		// }
-		if err = p.writeFieldData(cxt, oprot, v); err != nil {
+		//	<field-data>     ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+		//			<struct> | <map> | <list> | <set>
+		if err = v.WriteFieldData(cxt, oprot); err != nil {
 			err = thrift.PrependError(fmt.Sprintf("%T write list field data error", p), err)
-			return
 		}
 	}
 
 	if err = oprot.WriteListEnd(cxt); err != nil {
 		err = thrift.PrependError(fmt.Sprintf("%T write list end error", p), err)
 		return
-	}
-	return
-}
-
-// See the above spec.
-//
-//	<field-data>     ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
-//			<struct> | <map> | <list> | <set>
-func (p *TList) writeFieldData(cxt context.Context, oprot thrift.TProtocol, value TValue) (err error) {
-	if o, ok := value.(TString); ok {
-		err = oprot.WriteString(cxt, o.value)
-	} else if o, ok := value.(TBool); ok {
-		err = oprot.WriteBool(cxt, o.value)
-	} else if o, ok := value.(*TMap); ok {
-		err = o.WriteFieldData(cxt, oprot)
-	} else if o, ok := value.(*TStruct); ok {
-		err = o.WriteFieldData(cxt, oprot)
 	}
 	return
 }

--- a/tlist.go
+++ b/tlist.go
@@ -35,22 +35,18 @@ func (p *TList) Equals(other *TValue) bool {
 
 // See [Thrift IDL protocol spec]
 //
-//		<field>          ::= <field-begin> <list> <field-end>
-//		<list>           ::= <list-begin> <field-data>* <list-end>
-//	     <list-begin>     ::= <list-elem-type> <list-size>
-//	     <list-elem-type> ::= <field-type>
-//	     <list-size>      ::= I32
-//		<field-data>     ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
-//		                 <struct> | <map> | <list> | <set>
+//	<field>          ::= <field-begin> <list> <field-end>
+//	<list>           ::= <list-begin> <field-data>* <list-end>
+//	<list-begin>     ::= <list-elem-type> <list-size>
+//	<list-elem-type> ::= <field-type>
+//	<list-size>      ::= I32
+//	<field-data>     ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+//			<struct> | <map> | <list> | <set>
 //
 // [Thrift IDL protocol spec]: https://github.com/apache/thrift/blob/eec0b584e657e4250e22f3fd492858d632e2aa7b/doc/specs/thrift-protocol-spec.md
-func (p *TList) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
-	if err = oprot.WriteFieldBegin(cxt, fname, thrift.LIST, fid); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
-		return
-	}
+func (p *TList) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err error) {
 	if err = oprot.WriteListBegin(cxt, p.valueType, len(p.value)); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write list begin error %d:%s", p, fid, fname), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write list begin error", p), err)
 		return
 	}
 
@@ -59,18 +55,14 @@ func (p *TList) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int1
 		// 	err = thrift.PrependError(fmt.Sprintf("%T write list field data (field %d) error", p, fid), err)
 		// 	return
 		// }
-		if err = p.writeFieldData(cxt, oprot, v, fid, fname); err != nil {
-			err = thrift.PrependError(fmt.Sprintf("%T write list field data (field %d) error", p, fid), err)
+		if err = p.writeFieldData(cxt, oprot, v); err != nil {
+			err = thrift.PrependError(fmt.Sprintf("%T write list field data error", p), err)
 			return
 		}
 	}
 
 	if err = oprot.WriteListEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write list end error %d:%s: ", p, fid, fname), err)
-		return
-	}
-	if err = oprot.WriteFieldEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write list end error", p), err)
 		return
 	}
 	return
@@ -79,16 +71,20 @@ func (p *TList) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int1
 // See the above spec.
 //
 //	<field-data>     ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
-//	                 <struct> | <map> | <list> | <set>
-func (p *TList) writeFieldData(cxt context.Context, oprot thrift.TProtocol, value TValue, fid int16, fname string) (err error) {
+//			<struct> | <map> | <list> | <set>
+func (p *TList) writeFieldData(cxt context.Context, oprot thrift.TProtocol, value TValue) (err error) {
 	if o, ok := value.(TString); ok {
 		err = oprot.WriteString(cxt, o.value)
 	} else if o, ok := value.(TBool); ok {
 		err = oprot.WriteBool(cxt, o.value)
 	} else if o, ok := value.(*TMap); ok {
-		err = o.WriteField(cxt, oprot, fid, fname)
+		err = o.WriteFieldData(cxt, oprot)
 	} else if o, ok := value.(*TStruct); ok {
-		err = o.WriteField(cxt, oprot, fid, fname)
+		err = o.WriteFieldData(cxt, oprot)
 	}
 	return
+}
+
+func (p *TList) TType() thrift.TType {
+	return thrift.LIST
 }

--- a/tmap.go
+++ b/tmap.go
@@ -36,35 +36,27 @@ func (p *TMap) Equals(other *TValue) bool {
 
 // See [Thrift IDL protocol spec]
 //
-//   <field>      ::= <field-begin> <map> <field-end>
-//   <map>        ::= <map-begin> <field-data>* <map-end>
-//   <field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
-//                    <struct> | <map> | <list> | <set>
+//	<field>      ::= <field-begin> <map> <field-end>
+//	<map>        ::= <map-begin> <field-data>* <map-end>
+//	<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+//	                 <struct> | <map> | <list> | <set>
 //
 // [Thrift IDL protocol spec]: https://github.com/apache/thrift/blob/eec0b584e657e4250e22f3fd492858d632e2aa7b/doc/specs/thrift-protocol-spec.md
-func (p *TMap) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
-	if err = oprot.WriteFieldBegin(cxt, fname, thrift.MAP, fid); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
-		return
-	}
+func (p *TMap) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err error) {
 	if err = oprot.WriteMapBegin(cxt, p.keyType, p.valueType, len(p.value)); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write map begin error %d:%s", p, fid, fname), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write map begin error", p), err)
 		return
 	}
 
 	for k, v := range p.value {
 		if err = p.writeFieldDataKeyValue(cxt, oprot, k, v); err != nil {
-			err = thrift.PrependError(fmt.Sprintf("%T write key value (field %d) error", p, fid), err)
+			err = thrift.PrependError(fmt.Sprintf("%T write key value error", p), err)
 			return
 		}
 	}
 
 	if err = oprot.WriteMapEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write map end error %d:%s", p, fid, fname), err)
-		return
-	}
-	if err = oprot.WriteFieldEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write map end error", p), err)
 		return
 	}
 
@@ -73,9 +65,9 @@ func (p *TMap) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16
 
 // See the above spec.
 //
-//   <map>        ::= <map-begin> <field-data>* <map-end>
-//   <field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
-//                    <struct> | <map> | <list> | <set>
+//	<map>        ::= <map-begin> <field-data>* <map-end>
+//	<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+//			<struct> | <map> | <list> | <set>
 func (p *TMap) writeFieldDataKeyValue(cxt context.Context, oprot thrift.TProtocol, k, v TValue) (err error) {
 	if err = p.writeFieldData(cxt, oprot, k); err != nil {
 		return
@@ -88,8 +80,8 @@ func (p *TMap) writeFieldDataKeyValue(cxt context.Context, oprot thrift.TProtoco
 
 // See the above spec.
 //
-//   <field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
-//                    <struct> | <map> | <list> | <set>
+//	<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+//			<struct> | <map> | <list> | <set>
 func (p *TMap) writeFieldData(cxt context.Context, oprot thrift.TProtocol, value TValue) (err error) {
 	if o, ok := value.(TString); ok {
 		err = oprot.WriteString(cxt, o.value)
@@ -99,4 +91,8 @@ func (p *TMap) writeFieldData(cxt context.Context, oprot thrift.TProtocol, value
 		return
 	}
 	return
+}
+
+func (p *TMap) TType() thrift.TType {
+	return thrift.MAP
 }

--- a/trequest.go
+++ b/trequest.go
@@ -52,7 +52,18 @@ func (p *TRequest) writeFields(cxt context.Context, oprot thrift.TProtocol) (err
 	}
 
 	for fid, v := range p.values {
-		if err = v.WriteField(cxt, oprot, fid, "dummy"); err != nil {
+		ttype := v.TType()
+		fname := "dummy"
+
+		if err = oprot.WriteFieldBegin(cxt, fname, ttype, fid); err != nil {
+			err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
+			return
+		}
+		if err = v.WriteFieldData(cxt, oprot); err != nil {
+			return
+		}
+		if err = oprot.WriteFieldEnd(cxt); err != nil {
+			err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
 			return
 		}
 	}

--- a/tstring.go
+++ b/tstring.go
@@ -25,22 +25,18 @@ func (p TString) Equals(other *TValue) bool {
 
 // See [Thrift IDL protocol spec]
 //
-//   <field> ::= <field-begin> <field-data> <field-end>
-//   <field-data> ::= STRING
+//	<field> ::= <field-begin> <field-data> <field-end>
+//	<field-data> ::= STRING
 //
 // [Thrift IDL protocol spec]: https://github.com/apache/thrift/blob/eec0b584e657e4250e22f3fd492858d632e2aa7b/doc/specs/thrift-protocol-spec.md
-func (p TString) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
-	if err = oprot.WriteFieldBegin(cxt, fname, thrift.STRING, fid); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
-		return
-	}
+func (p TString) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err error) {
 	if err = oprot.WriteString(cxt, string(p.value)); err != nil {
 		err = thrift.PrependError(fmt.Sprintf("%T.id (1) field write error: ", p), err)
 		return
 	}
-	if err = oprot.WriteFieldEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
-		return
-	}
 	return
+}
+
+func (p TString) TType() thrift.TType {
+	return thrift.STRING
 }

--- a/tstruct.go
+++ b/tstruct.go
@@ -82,11 +82,11 @@ func (p *TStruct) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (e
 	}
 
 	if err = oprot.WriteFieldStop(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) stop error: ", p), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write struct stop error: ", p), err)
 		return
 	}
 	if err = oprot.WriteStructEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) end error: ", p), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
 		return
 	}
 	return

--- a/tstruct.go
+++ b/tstruct.go
@@ -49,18 +49,15 @@ func (p *TStruct) Equals(other *TValue) bool {
 // see [Thrift protocol spec @ 1a31d90 (v0.21.0)].
 //
 //	<field> ::= <field-begin> <field-data> <field-end>
-//		<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
-//	<struct> | <map> | <list> | <set>
+//	<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+//			<struct> | <map> | <list> | <set>
 //	<struct> ::= <struct-begin> <field>* <field-stop> <struct-end>
 //
 // [Thrift protocol spec @ 1a31d90 (v0.21.0)]: https://github.com/apache/thrift/blob/1a31d9051d35b732a5fce258955ef95f576694ba/doc/specs/thrift-protocol-spec.md (v0.21.0)
-func (p *TStruct) WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) (err error) {
-	if err = oprot.WriteFieldBegin(cxt, fname, thrift.STRUCT, fid); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s: ", p, fid, fname), err)
-		return
-	}
-	if err = oprot.WriteStructBegin(cxt, fname); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) begin error: ", p, fid, fname), err)
+func (p *TStruct) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err error) {
+	structName := "dummy"
+	if err = oprot.WriteStructBegin(cxt, structName); err != nil {
+		err = thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
 		return
 	}
 
@@ -68,23 +65,33 @@ func (p *TStruct) WriteField(cxt context.Context, oprot thrift.TProtocol, fid in
 	for _, f := range slices.SortedFunc(maps.Keys(p.value), func(a, b TStructField) int {
 		return int(a.id) - int(b.id)
 	}) {
-		err = p.value[f].WriteField(cxt, oprot, f.id, f.name)
-		if err != nil {
+		v := p.value[f]
+		ttype := v.TType()
+
+		if err = oprot.WriteFieldBegin(cxt, f.name, ttype, f.id); err != nil {
+			err = thrift.PrependError(fmt.Sprintf("%T write field begin error %d:%s", p, f.id, f.name), err)
+			return
+		}
+		if err = v.WriteFieldData(cxt, oprot); err != nil {
+			return
+		}
+		if err = oprot.WriteFieldEnd(cxt); err != nil {
+			err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s", p, f.id, f.name), err)
 			return
 		}
 	}
 
 	if err = oprot.WriteFieldStop(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) stop error: ", p, fid, fname), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) stop error: ", p), err)
 		return
 	}
 	if err = oprot.WriteStructEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) end error: ", p, fid, fname), err)
-		return
-	}
-	if err = oprot.WriteFieldEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write field end error %d:%s: ", p, fid, fname), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write struct (%d, %s) end error: ", p), err)
 		return
 	}
 	return
+}
+
+func (p *TStruct) TType() thrift.TType {
+	return thrift.STRUCT
 }

--- a/tvalue.go
+++ b/tvalue.go
@@ -8,7 +8,15 @@ import (
 
 type TValue interface {
 	Equals(other *TValue) bool
-	// WriteField outputs TValue to Thrift protocol with field ID `fid` and field name `fname`.
-	// This must start with `WriteFieldBegin` method call, and end with `WriteFieldEnd` method call.
-	WriteField(cxt context.Context, oprot thrift.TProtocol, fid int16, fname string) error
+	// WriteFieldData outputs TValue to Thrift protocol with field ID `fid` and field name `fname`.
+	// This is equivalent to `<field-data>` in [Thrift protocol spec].
+	//
+	//	<field> ::= <field-begin> <field-data> <field-end>
+	//	<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
+	//			<struct> | <map> | <list> | <set>
+	//
+	// [Thrift protocol spec]: https://github.com/apache/thrift/blob/1a31d9051d35b732a5fce258955ef95f576694ba/doc/specs/thrift-protocol-spec.md (v0.21.0)
+	WriteFieldData(cxt context.Context, oprot thrift.TProtocol) error
+	// TType returns type in Thrift.
+	TType() thrift.TType
 }


### PR DESCRIPTION
# Overview

Refactoring project.
First of all, refactor the field writing method `TValue#WriteField`

# What's changed

- Change `TValue` just write `<field-data>`, not `<field>`.
  - the difference between them is written in https://github.com/apache/thrift/blob/eec0b584e657e4250e22f3fd492858d632e2aa7b/doc/specs/thrift-protocol-spec.md.
  - renamed to `WriteFieldData`
- Change to write the item in Thrift container data to use `TValue#WriteFieldData`.

## Why just write `<field-data>`, not `<field>`

To.
- simplify implementation.
- write ANY type in the container type (`list` / `map` / `struct`).

e.g.
```
    <field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
                     <struct> | <map> | <list> | <set>
AND
           <map> ::= <map-begin> <field-datum>* <map-end>
     <map-begin> ::= <map-key-type> <map-value-type> <map-size>
  <map-key-type> ::= <field-type>
<map-value-type> ::= <field-type>
      <map-size> ::= I32
```

By writing just `<field-data>`, it gets easy to write an item in the container by calling `TValue.WriteFieldData()`.
https://github.com/lavenderses/xk6-thrift/pull/26/files?diff=split&w=1#diff-29bfe27dffbaba857ab15abe7f4548a47e4b631756ce47891d4396e9070e0bd1R51-R63

## TODOs

- [ ] Refactor read method.