### PR TITLE
Refactor boolean read method in response

### DIFF
--- a/tbool.go
+++ b/tbool.go
@@ -36,7 +36,16 @@ func (p TBool) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err 
 	}
 	return
 }
-
 func (p TBool) TType() thrift.TType {
 	return thrift.BOOL
+}
+
+func ReadBool(cxt context.Context, iprot thrift.TProtocol) (TValue, error) {
+	v, err := iprot.ReadBool(cxt)
+	if err != nil {
+		return nil, thrift.PrependError(fmt.Sprintf("error reading boolean"), err)
+	}
+
+	res := NewTBool(v)
+	return res, nil
 }

--- a/tbool.go
+++ b/tbool.go
@@ -43,7 +43,7 @@ func (p TBool) TType() thrift.TType {
 func ReadBool(cxt context.Context, iprot thrift.TProtocol) (TValue, error) {
 	v, err := iprot.ReadBool(cxt)
 	if err != nil {
-		return nil, thrift.PrependError(fmt.Sprintf("error reading boolean"), err)
+		return nil, thrift.PrependError("error while reading boolean", err)
 	}
 
 	res := NewTBool(v)

--- a/tresponse.go
+++ b/tresponse.go
@@ -43,7 +43,7 @@ func (p *TResponse) Read(cxt context.Context, iprot thrift.TProtocol) error {
 			case thrift.STRING:
 				v, err = p.ReadString(cxt, iprot, fieldId)
 			case thrift.BOOL:
-				v, err = p.ReadBool(cxt, iprot, fieldId)
+				v, err = ReadBool(cxt, iprot)
 			case thrift.LIST:
 				v, err = p.ReadList(cxt, iprot, fieldId)
 			case thrift.MAP:
@@ -71,16 +71,6 @@ func (p *TResponse) ReadString(cxt context.Context, iproto thrift.TProtocol, fie
 	}
 
 	res := NewTstring(v)
-	return &res, nil
-}
-
-func (p *TResponse) ReadBool(cxt context.Context, iproto thrift.TProtocol, fieldId int16) (*TBool, error) {
-	v, err := iproto.ReadBool(cxt)
-	if err != nil {
-		return nil, thrift.PrependError(fmt.Sprintf("error reading boolean field %d: ", fieldId), err)
-	}
-
-	res := NewTBool(v)
 	return &res, nil
 }
 
@@ -195,7 +185,7 @@ func (p *TResponse) ReadStruct(cxt context.Context, iprot thrift.TProtocol, fiel
 		case thrift.STRING:
 			tv, err = p.ReadString(cxt, iprot, fid)
 		case thrift.BOOL:
-			tv, err = p.ReadBool(cxt, iprot, fid)
+			tv, err = ReadBool(cxt, iprot)
 		case thrift.MAP:
 			tv, err = p.ReadMap(cxt, iprot, fid)
 		case thrift.STRUCT:


### PR DESCRIPTION
# Overview

Following.
- https://github.com/lavenderses/xk6-thrift/pull/26

Refactoring project.
The write method has been brushed up in the PR. The read methods will be done too in the next PRs.

# What's changed

- Change `ReadBool` method to function, and move it to tbool.go file.
