### PR TITLE
Refactor ReadString

### DIFF
--- a/tresponse.go
+++ b/tresponse.go
@@ -41,7 +41,7 @@ func (p *TResponse) Read(cxt context.Context, iprot thrift.TProtocol) error {
 			var v TValue
 			switch fieldTypeId {
 			case thrift.STRING:
-				v, err = p.ReadString(cxt, iprot, fieldId)
+				v, err = ReadString(cxt, iprot)
 			case thrift.BOOL:
 				v, err = ReadBool(cxt, iprot)
 			case thrift.LIST:
@@ -62,16 +62,6 @@ func (p *TResponse) Read(cxt context.Context, iprot thrift.TProtocol) error {
 	}
 
 	return nil
-}
-
-func (p *TResponse) ReadString(cxt context.Context, iproto thrift.TProtocol, fieldId int16) (*TString, error) {
-	v, err := iproto.ReadString(cxt)
-	if err != nil {
-		return nil, thrift.PrependError(fmt.Sprintf("error reading string field %d: ", fieldId), err)
-	}
-
-	res := NewTstring(v)
-	return &res, nil
 }
 
 func (p *TResponse) ReadMap(cxt context.Context, iproto thrift.TProtocol, fieldId int16) (*TMap, error) {
@@ -183,7 +173,7 @@ func (p *TResponse) ReadStruct(cxt context.Context, iprot thrift.TProtocol, fiel
 		// slog.Info(fmt.Sprintf("GOT %s, %v, %d", fieldName, fieldTypeId, fieldId))
 		switch ftype {
 		case thrift.STRING:
-			tv, err = p.ReadString(cxt, iprot, fid)
+			tv, err = ReadString(cxt, iprot)
 		case thrift.BOOL:
 			tv, err = ReadBool(cxt, iprot)
 		case thrift.MAP:

--- a/tstring.go
+++ b/tstring.go
@@ -40,3 +40,13 @@ func (p TString) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (er
 func (p TString) TType() thrift.TType {
 	return thrift.STRING
 }
+
+func ReadString(cxt context.Context, iproto thrift.TProtocol) (TValue, error) {
+	v, err := iproto.ReadString(cxt)
+	if err != nil {
+		return nil, thrift.PrependError(fmt.Sprintf("error while reading string field"), err)
+	}
+
+	res := NewTstring(v)
+	return res, nil
+}

--- a/tstring.go
+++ b/tstring.go
@@ -44,7 +44,7 @@ func (p TString) TType() thrift.TType {
 func ReadString(cxt context.Context, iproto thrift.TProtocol) (TValue, error) {
 	v, err := iproto.ReadString(cxt)
 	if err != nil {
-		return nil, thrift.PrependError(fmt.Sprintf("error while reading string field"), err)
+		return nil, thrift.PrependError("error while reading string field", err)
 	}
 
 	res := NewTstring(v)


### PR DESCRIPTION
# Overview

Following.
- https://github.com/lavenderses/xk6-thrift/pull/26

Refactoring project.
The write method has been brushed up in the PR. The read methods will be done too in the next PRs.

# What's changed

- Change `ReadString` method to function, and move it to tbool.go file.
- Remove field ID to argument, which is unnecessary.
