### PR TITLE
Refactor ReadMap

### DIFF
--- a/tcontainer.go
+++ b/tcontainer.go
@@ -1,0 +1,30 @@
+package thrift
+
+import (
+	"context"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+func ReadContainerData(ttype thrift.TType, cxt context.Context, iprot thrift.TProtocol) (TValue, error) {
+	var tv TValue
+	var err error
+
+	switch ttype {
+	case thrift.STRING:
+		tv, err = ReadString(cxt, iprot)
+	case thrift.BOOL:
+		tv, err = ReadBool(cxt, iprot)
+	case thrift.MAP:
+		tv, err = ReadMap(cxt, iprot)
+	// case thrift.STRUCT:
+	// 	tv, err = ReadStruct(cxt, iprot)
+	default:
+		err = iprot.Skip(cxt, ttype)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return tv, err
+}

--- a/tmap.go
+++ b/tmap.go
@@ -73,3 +73,34 @@ func (p *TMap) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err 
 func (p *TMap) TType() thrift.TType {
 	return thrift.MAP
 }
+
+func ReadMap(cxt context.Context, iproto thrift.TProtocol) (TValue, error) {
+	keyType, valueType, size, err := iproto.ReadMapBegin(cxt)
+	if err != nil {
+		return nil, thrift.PrependError("error while reading map field", err)
+	}
+
+	tmap := make(map[TValue]TValue)
+	for i := 0; i < size; i++ {
+		if err = readFeidlDataList(cxt, iproto, &tmap, keyType, valueType); err != nil {
+			return nil, thrift.PrependError("error while reading map", err)
+		}
+	}
+
+	res := NewTMap(&tmap)
+	return res, nil
+}
+
+func readFeidlDataList(cxt context.Context, iprot thrift.TProtocol, tmap *map[TValue]TValue, ktype, vtype thrift.TType) error {
+	var key, value TValue
+	var err error
+	if key, err = ReadContainerData(ktype, cxt, iprot); err != nil {
+		return err
+	}
+	if value, err = ReadContainerData(vtype, cxt, iprot); err != nil {
+		return err
+	}
+
+	(*tmap)[key] = value
+	return nil
+}

--- a/tresponse.go
+++ b/tresponse.go
@@ -47,7 +47,7 @@ func (p *TResponse) Read(cxt context.Context, iprot thrift.TProtocol) error {
 			case thrift.LIST:
 				v, err = p.ReadList(cxt, iprot, fieldId)
 			case thrift.MAP:
-				v, err = p.ReadMap(cxt, iprot, fieldId)
+				v, err = ReadMap(cxt, iprot)
 			case thrift.STRUCT:
 				v, err = p.ReadStruct(cxt, iprot, fieldId)
 			}
@@ -62,56 +62,6 @@ func (p *TResponse) Read(cxt context.Context, iprot thrift.TProtocol) error {
 	}
 
 	return nil
-}
-
-func (p *TResponse) ReadMap(cxt context.Context, iproto thrift.TProtocol, fieldId int16) (*TMap, error) {
-	keyType, valueType, size, err := iproto.ReadMapBegin(cxt)
-	if err != nil {
-		return nil, thrift.PrependError(fmt.Sprintf("error reading map field %d: ", fieldId), err)
-	}
-
-	tmap := make(map[TValue]TValue)
-	for i := 0; i < size; i++ {
-		if err = p.readFeidlDataList(cxt, iproto, &tmap, keyType, valueType); err != nil {
-			return nil, thrift.PrependError(fmt.Sprintf("error reading map %d: ", fieldId), err)
-		}
-	}
-
-	res := NewTMap(&tmap)
-	return res, nil
-}
-
-func (p *TResponse) readFeidlDataList(cxt context.Context, iprot thrift.TProtocol, tmap *map[TValue]TValue, ktype, vtype thrift.TType) error {
-	var key, value TValue
-	var err error
-	if key, err = p.readField(cxt, iprot, ktype); err != nil {
-		return err
-	}
-	if value, err = p.readField(cxt, iprot, vtype); err != nil {
-		return err
-	}
-
-	(*tmap)[key] = value
-	return nil
-}
-
-func (p *TResponse) readField(cxt context.Context, iprot thrift.TProtocol, ttype thrift.TType) (tv TValue, err error) {
-	switch ttype {
-	case thrift.STRING:
-		if v, err := iprot.ReadString(cxt); err != nil {
-			return nil, err
-		} else {
-			tv = NewTstring(v)
-		}
-	case thrift.BOOL:
-		if v, err := iprot.ReadBool(cxt); err != nil {
-			return nil, err
-		} else {
-			tv = NewTBool(v)
-		}
-	}
-
-	return
 }
 
 func (p *TResponse) ReadList(cxt context.Context, iproto thrift.TProtocol, fieldId int16) (*TList, error) {
@@ -177,7 +127,7 @@ func (p *TResponse) ReadStruct(cxt context.Context, iprot thrift.TProtocol, fiel
 		case thrift.BOOL:
 			tv, err = ReadBool(cxt, iprot)
 		case thrift.MAP:
-			tv, err = p.ReadMap(cxt, iprot, fid)
+			tv, err = ReadMap(cxt, iprot)
 		case thrift.STRUCT:
 			tv, err = p.ReadStruct(cxt, iprot, fid)
 		default:


### PR DESCRIPTION
# Overview

Following.
- https://github.com/lavenderses/xk6-thrift/pull/26

Refactoring project.
The write method has been brushed up in the PR. The read methods will be done too in the next PRs.

# What's changed

- Introduced `ReadContainerData` function, which reads data in _container data_ (list, map, set and struct)
- Change `ReadMap` method to function, and move it to tmap.go file.
  - Use `ReadContainerData` for reading key value in map.
