### PR TITLE
Refactor ReadList

### DIFF
--- a/tcontainer.go
+++ b/tcontainer.go
@@ -15,6 +15,8 @@ func ReadContainerData(ttype thrift.TType, cxt context.Context, iprot thrift.TPr
 		tv, err = ReadString(cxt, iprot)
 	case thrift.BOOL:
 		tv, err = ReadBool(cxt, iprot)
+	case thrift.LIST:
+		tv, err = ReadList(cxt, iprot)
 	case thrift.MAP:
 		tv, err = ReadMap(cxt, iprot)
 	case thrift.STRUCT:

--- a/tlist.go
+++ b/tlist.go
@@ -69,3 +69,23 @@ func (p *TList) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err
 func (p *TList) TType() thrift.TType {
 	return thrift.LIST
 }
+
+func ReadList(cxt context.Context, iprot thrift.TProtocol) (TValue, error) {
+	valueType, size, err := iprot.ReadListBegin(cxt)
+	if err != nil {
+		return nil, thrift.PrependError("error while reading list begin", err)
+	}
+
+	var tlist []TValue
+	for i := 0; i < size; i++ {
+		var tv TValue
+		tv, err = ReadContainerData(valueType, cxt, iprot)
+		if err != nil {
+			return nil, thrift.PrependError("error reading list field", err)
+		}
+		tlist = append(tlist, tv)
+	}
+
+	res := NewTList(&tlist, valueType)
+	return res, nil
+}

--- a/tresponse.go
+++ b/tresponse.go
@@ -39,18 +39,11 @@ func (p *TResponse) Read(cxt context.Context, iprot thrift.TProtocol) error {
 		switch fieldId {
 		case 0:
 			var v TValue
-			switch fieldTypeId {
-			case thrift.STRING:
-				v, err = ReadString(cxt, iprot)
-			case thrift.BOOL:
-				v, err = ReadBool(cxt, iprot)
-			case thrift.LIST:
-				v, err = p.ReadList(cxt, iprot, fieldId)
-			case thrift.MAP:
-				v, err = ReadMap(cxt, iprot)
-			case thrift.STRUCT:
-				v, err = ReadStruct(cxt, iprot)
+			v, err = ReadContainerData(fieldTypeId, cxt, iprot)
+			if err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T read field (%d, %v) error: ", p, fieldId, fieldTypeId), err)
 			}
+
 			p.values[fieldId] = v
 		default:
 			err = iprot.Skip(cxt, fieldTypeId)
@@ -62,45 +55,6 @@ func (p *TResponse) Read(cxt context.Context, iprot thrift.TProtocol) error {
 	}
 
 	return nil
-}
-
-func (p *TResponse) ReadList(cxt context.Context, iproto thrift.TProtocol, fieldId int16) (*TList, error) {
-	valueType, size, err := iproto.ReadListBegin(cxt)
-	if err != nil {
-		return nil, thrift.PrependError(fmt.Sprintf("error reading list field %d: ", fieldId), err)
-	}
-
-	var tlist []TValue
-	for i := 0; i < size; i++ {
-		var tv TValue
-		tv, err = p.readListField(cxt, iproto, valueType)
-		if err != nil {
-			return nil, thrift.PrependError(fmt.Sprintf("error reading list %d: ", fieldId), err)
-		}
-		tlist = append(tlist, tv)
-	}
-
-	res := NewTList(&tlist, valueType)
-	return res, nil
-}
-
-func (p *TResponse) readListField(cxt context.Context, iprot thrift.TProtocol, ttype thrift.TType) (tv TValue, err error) {
-	switch ttype {
-	case thrift.STRING:
-		if v, err := iprot.ReadString(cxt); err != nil {
-			return nil, err
-		} else {
-			tv = NewTstring(v)
-		}
-	case thrift.BOOL:
-		if v, err := iprot.ReadBool(cxt); err != nil {
-			return nil, err
-		} else {
-			tv = NewTBool(v)
-		}
-	}
-
-	return
 }
 
 // dummy.


### PR DESCRIPTION
# Overview

Following.

- https://github.com/lavenderses/xk6-thrift/pull/26

Refactoring project.
The write method has been brushed up in the PR. The read methods will be done too in the next PRs.

# What's changed

- Change the `ReadList` method to function, and move it to tstruct.go
- Use `ReadContainerData` in it, which is introduced in https://github.com/lavenderses/xk6-thrift/pull/29.
