### PR TITLE
Add Unit test for boolean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           args: . ./it/...
 
-  test:
+  it:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -66,7 +66,27 @@ jobs:
             res=$(curl 127.0.0.1:8080/health || echo "NG")
           done
 
-
       - name: test
         run:
           go test -v ./it
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: install deps
+        run: |
+          go get .
+
+      - name: test
+        run:
+          go test -v .

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,38 @@
+package thrift
+
+import (
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+func setupProtocol(t *testing.T) thrift.TProtocol {
+	tf := thrift.NewTMemoryBufferTransportFactory(1_024)
+	trans, err := tf.GetTransport(nil)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	pf := thrift.NewTJSONProtocolFactory()
+	debugPf := thrift.TDebugProtocolFactory{
+		Underlying: pf,
+		LogPrefix:  "xk6-thrif5",
+	}
+	return debugPf.GetProtocol(trans)
+}
+
+func checkError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+}
+
+func assertTrue(t *testing.T, title string, result bool) {
+	assert(t, title, result, true)
+}
+
+func assert[T string | bool | int | thrift.TType](t *testing.T, title string, actual, expected T) {
+	if actual != expected {
+		t.Fatalf("[%v] Expected %v but was %v", title, expected, actual)
+	}
+}

--- a/tbool.go
+++ b/tbool.go
@@ -36,6 +36,7 @@ func (p TBool) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err 
 	}
 	return
 }
+
 func (p TBool) TType() thrift.TType {
 	return thrift.BOOL
 }
@@ -43,7 +44,7 @@ func (p TBool) TType() thrift.TType {
 func ReadBool(cxt context.Context, iprot thrift.TProtocol) (TValue, error) {
 	v, err := iprot.ReadBool(cxt)
 	if err != nil {
-		return nil, thrift.PrependError("error while reading boolean", err)
+		return nil, thrift.PrependError("error while reading boolean: ", err)
 	}
 
 	res := NewTBool(v)

--- a/tbool_test.go
+++ b/tbool_test.go
@@ -1,0 +1,116 @@
+package thrift
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEquals_TBool_equals(t *testing.T) {
+	// prepare
+	a := NewTBool(true)
+	var b TValue
+	b = NewTBool(true)
+	expected := true
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestEquals_TBool_not_equals(t *testing.T) {
+	// prepare
+	a := NewTBool(true)
+	var b TValue
+	b = NewTBool(false)
+	expected := false
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestEquals_TBool_other_type(t *testing.T) {
+	// prepare
+	a := NewTBool(true)
+	var b TValue
+	b = NewTstring("other")
+	expected := false
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestWriteFieldData(t *testing.T) {
+	// prepare
+	oprot := setupProtocol(t)
+	cxt := context.Background()
+	value := NewTBool(true)
+	expected := true
+
+	// do
+	err := value.WriteFieldData(cxt, oprot)
+	checkError(t, err)
+
+	// verify
+	oprot.Flush(cxt)
+	actual, err := oprot.ReadBool(cxt)
+	checkError(t, err)
+	assert(t, "", actual, expected)
+}
+
+func TestReadBool_true(t *testing.T) {
+	// prepare
+	iprot := setupProtocol(t)
+	cxt := context.Background()
+	iprot.WriteBool(cxt, true)
+	iprot.Flush(cxt)
+
+	// do
+	actual, err := ReadBool(cxt, iprot)
+	checkError(t, err)
+
+	// verfiy
+	e := NewTBool(true)
+	a, ok := actual.(TBool)
+	assertTrue(t, "cast to TBool", ok)
+	assert(t, "result", a.value, e.value)
+}
+
+func TestReadBool_false(t *testing.T) {
+	// prepare
+	iprot := setupProtocol(t)
+	cxt := context.Background()
+	iprot.WriteBool(cxt, false)
+	iprot.Flush(cxt)
+
+	// do
+	actual, err := ReadBool(cxt, iprot)
+	checkError(t, err)
+
+	// verfiy
+	e := NewTBool(false)
+	a, ok := actual.(TBool)
+	assertTrue(t, "cast to TBool", ok)
+	assert(t, "result", a.value, e.value)
+}
+
+func TestReadBool_invalid_type(t *testing.T) {
+	// prepare
+	iprot := setupProtocol(t)
+	cxt := context.Background()
+	iprot.WriteString(cxt, "FOO")
+	iprot.Flush(cxt)
+
+	// do
+	_, err := ReadBool(cxt, iprot)
+
+	// verfiy
+	assertTrue(t, "error expected", err != nil)
+}

--- a/tbool_test.go
+++ b/tbool_test.go
@@ -8,8 +8,7 @@ import (
 func TestEquals_TBool_equals(t *testing.T) {
 	// prepare
 	a := NewTBool(true)
-	var b TValue
-	b = NewTBool(true)
+	var b TValue = NewTBool(true)
 	expected := true
 
 	// do
@@ -22,8 +21,7 @@ func TestEquals_TBool_equals(t *testing.T) {
 func TestEquals_TBool_not_equals(t *testing.T) {
 	// prepare
 	a := NewTBool(true)
-	var b TValue
-	b = NewTBool(false)
+	var b TValue = NewTBool(false)
 	expected := false
 
 	// do
@@ -36,8 +34,7 @@ func TestEquals_TBool_not_equals(t *testing.T) {
 func TestEquals_TBool_other_type(t *testing.T) {
 	// prepare
 	a := NewTBool(true)
-	var b TValue
-	b = NewTstring("other")
+	var b TValue = NewTstring("other")
 	expected := false
 
 	// do
@@ -69,8 +66,14 @@ func TestReadBool_true(t *testing.T) {
 	// prepare
 	iprot := setupProtocol(t)
 	cxt := context.Background()
-	iprot.WriteBool(cxt, true)
-	iprot.Flush(cxt)
+	checkError(
+		t,
+		iprot.WriteBool(cxt, true),
+	)
+	checkError(
+		t,
+		iprot.Flush(cxt),
+	)
 
 	// do
 	actual, err := ReadBool(cxt, iprot)
@@ -87,8 +90,14 @@ func TestReadBool_false(t *testing.T) {
 	// prepare
 	iprot := setupProtocol(t)
 	cxt := context.Background()
-	iprot.WriteBool(cxt, false)
-	iprot.Flush(cxt)
+	checkError(
+		t,
+		iprot.WriteBool(cxt, false),
+	)
+	checkError(
+		t,
+		iprot.Flush(cxt),
+	)
 
 	// do
 	actual, err := ReadBool(cxt, iprot)
@@ -105,8 +114,14 @@ func TestReadBool_invalid_type(t *testing.T) {
 	// prepare
 	iprot := setupProtocol(t)
 	cxt := context.Background()
-	iprot.WriteString(cxt, "FOO")
-	iprot.Flush(cxt)
+	checkError(
+		t,
+		iprot.WriteString(cxt, "FOO"),
+	)
+	checkError(
+		t,
+		iprot.Flush(cxt),
+	)
 
 	// do
 	_, err := ReadBool(cxt, iprot)


### PR DESCRIPTION
# Overview

Improve testing.

# What's changed

- Write unit test for `tbool.go`.
  - `Equal()`
  - `WriteFieldData` and assert it with Thrift's native read method.
  - `ReadString` and assert it using Thrift's native write method.
- Introduce helper method (assertion and error check).
- DO unit test in CI (new job).

## TODOs

- [ ] Refactor package structure.