### PR TITLE
Add unit test for map

### DIFF
--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -130,14 +130,14 @@ func TestMapCall(t *testing.T) {
 		xk6_thrift.NewTstring("key 2"): xk6_thrift.NewTBool(false),
 	}
 	tvalue := map[int16]xk6_thrift.TValue{
-		1: xk6_thrift.NewTMap(&value),
+		1: xk6_thrift.NewTMap(thrift.STRING, thrift.BOOL, &value),
 	}
 	arg := xk6_thrift.NewTRequestWithValue(&tvalue)
 	expectValue := map[xk6_thrift.TValue]xk6_thrift.TValue{
 		xk6_thrift.NewTstring("NEW: key 1"): xk6_thrift.NewTBool(true),
 		xk6_thrift.NewTstring("NEW: key 2"): xk6_thrift.NewTBool(false),
 	}
-	expectTValue := xk6_thrift.NewTMap(&expectValue)
+	expectTValue := xk6_thrift.NewTMap(thrift.STRING, thrift.BOOL, &expectValue)
 	expect := xk6_thrift.NewTResponse()
 	expect.Add(0, expectTValue)
 	actual := xk6_thrift.NewTResponse()
@@ -163,6 +163,8 @@ func TestMessageCall(t *testing.T) {
 	value := map[xk6_thrift.TStructField]xk6_thrift.TValue{
 		*xk6_thrift.NewTStructField(1, "content"): xk6_thrift.NewTstring("this is a content"),
 		*xk6_thrift.NewTStructField(2, "tags"): xk6_thrift.NewTMap(
+			thrift.STRING,
+			thrift.BOOL,
 			&map[xk6_thrift.TValue]xk6_thrift.TValue{
 				xk6_thrift.NewTstring("bool true"):  xk6_thrift.NewTBool(true),
 				xk6_thrift.NewTstring("bool false"): xk6_thrift.NewTBool(false),
@@ -181,6 +183,8 @@ func TestMessageCall(t *testing.T) {
 	expectValue := map[xk6_thrift.TStructField]xk6_thrift.TValue{
 		*xk6_thrift.NewTStructField(1, ""): xk6_thrift.NewTstring("content: this is a content"),
 		*xk6_thrift.NewTStructField(2, ""): xk6_thrift.NewTMap(
+			thrift.STRING,
+			thrift.BOOL,
 			&map[xk6_thrift.TValue]xk6_thrift.TValue{
 				xk6_thrift.NewTstring("bool true"):  xk6_thrift.NewTBool(true),
 				xk6_thrift.NewTstring("bool false"): xk6_thrift.NewTBool(false),
@@ -254,8 +258,10 @@ func TestStringsCall(t *testing.T) {
 	msg1 := map[xk6_thrift.TStructField]xk6_thrift.TValue{
 		*xk6_thrift.NewTStructField(1, "content"): xk6_thrift.NewTstring("content 1"),
 		*xk6_thrift.NewTStructField(2, "tags"): xk6_thrift.NewTMap(
+			thrift.STRING,
+			thrift.BOOL,
 			&map[xk6_thrift.TValue]xk6_thrift.TValue{
-				xk6_thrift.NewTstring("bool true"):  xk6_thrift.NewTBool(true),
+				xk6_thrift.NewTstring("bool true"): xk6_thrift.NewTBool(true),
 			},
 		),
 		*xk6_thrift.NewTStructField(3, "nested"): xk6_thrift.NewTStruct(
@@ -267,8 +273,10 @@ func TestStringsCall(t *testing.T) {
 	msg2 := map[xk6_thrift.TStructField]xk6_thrift.TValue{
 		*xk6_thrift.NewTStructField(1, "content"): xk6_thrift.NewTstring("content 2"),
 		*xk6_thrift.NewTStructField(2, "tags"): xk6_thrift.NewTMap(
+			thrift.STRING,
+			thrift.BOOL,
 			&map[xk6_thrift.TValue]xk6_thrift.TValue{
-				xk6_thrift.NewTstring("bool false"):  xk6_thrift.NewTBool(false),
+				xk6_thrift.NewTstring("bool false"): xk6_thrift.NewTBool(false),
 			},
 		),
 		*xk6_thrift.NewTStructField(3, "nested"): xk6_thrift.NewTStruct(
@@ -290,8 +298,10 @@ func TestStringsCall(t *testing.T) {
 	exMsg1 := map[xk6_thrift.TStructField]xk6_thrift.TValue{
 		*xk6_thrift.NewTStructField(1, ""): xk6_thrift.NewTstring(exChange + "content 1"),
 		*xk6_thrift.NewTStructField(2, ""): xk6_thrift.NewTMap(
+			thrift.STRING,
+			thrift.BOOL,
 			&map[xk6_thrift.TValue]xk6_thrift.TValue{
-				xk6_thrift.NewTstring("bool true"):  xk6_thrift.NewTBool(true),
+				xk6_thrift.NewTstring("bool true"): xk6_thrift.NewTBool(true),
 			},
 		),
 		*xk6_thrift.NewTStructField(3, ""): xk6_thrift.NewTStruct(
@@ -303,8 +313,10 @@ func TestStringsCall(t *testing.T) {
 	exMsg2 := map[xk6_thrift.TStructField]xk6_thrift.TValue{
 		*xk6_thrift.NewTStructField(1, ""): xk6_thrift.NewTstring(exChange + "content 2"),
 		*xk6_thrift.NewTStructField(2, ""): xk6_thrift.NewTMap(
+			thrift.STRING,
+			thrift.BOOL,
 			&map[xk6_thrift.TValue]xk6_thrift.TValue{
-				xk6_thrift.NewTstring("bool false"):  xk6_thrift.NewTBool(false),
+				xk6_thrift.NewTstring("bool false"): xk6_thrift.NewTBool(false),
 			},
 		),
 		*xk6_thrift.NewTStructField(3, ""): xk6_thrift.NewTStruct(

--- a/tmap.go
+++ b/tmap.go
@@ -13,8 +13,8 @@ type TMap struct {
 	valueType thrift.TType
 }
 
-func NewTMap(v *map[TValue]TValue) *TMap {
-	return &TMap{value: *v}
+func NewTMap(keyType, valueType thrift.TType, v *map[TValue]TValue) *TMap {
+	return &TMap{value: *v, keyType: keyType, valueType: valueType}
 }
 
 func (p *TMap) Equals(other *TValue) bool {
@@ -44,7 +44,7 @@ func (p *TMap) Equals(other *TValue) bool {
 // [Thrift IDL protocol spec]: https://github.com/apache/thrift/blob/eec0b584e657e4250e22f3fd492858d632e2aa7b/doc/specs/thrift-protocol-spec.md
 func (p *TMap) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err error) {
 	if err = oprot.WriteMapBegin(cxt, p.keyType, p.valueType, len(p.value)); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write map begin error", p), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write map begin error: ", p), err)
 		return
 	}
 
@@ -53,17 +53,17 @@ func (p *TMap) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) (err 
 		//	<field-data> ::= I8 | I16 | I32 | I64 | DOUBLE | STRING | BINARY
 		//			<struct> | <map> | <list> | <set>
 		if err = k.WriteFieldData(cxt, oprot); err != nil {
-			err = thrift.PrependError(fmt.Sprintf("%T write key error", p), err)
+			err = thrift.PrependError(fmt.Sprintf("%T write key error: ", p), err)
 			return
 		}
 		if err = v.WriteFieldData(cxt, oprot); err != nil {
-			err = thrift.PrependError(fmt.Sprintf("%T write value error", p), err)
+			err = thrift.PrependError(fmt.Sprintf("%T write value error: ", p), err)
 			return
 		}
 	}
 
 	if err = oprot.WriteMapEnd(cxt); err != nil {
-		err = thrift.PrependError(fmt.Sprintf("%T write map end error", p), err)
+		err = thrift.PrependError(fmt.Sprintf("%T write map end error: ", p), err)
 		return
 	}
 
@@ -77,17 +77,17 @@ func (p *TMap) TType() thrift.TType {
 func ReadMap(cxt context.Context, iproto thrift.TProtocol) (TValue, error) {
 	keyType, valueType, size, err := iproto.ReadMapBegin(cxt)
 	if err != nil {
-		return nil, thrift.PrependError("error while reading map field", err)
+		return nil, thrift.PrependError("error while reading map field: ", err)
 	}
 
 	tmap := make(map[TValue]TValue)
 	for i := 0; i < size; i++ {
 		if err = readFeidlDataList(cxt, iproto, &tmap, keyType, valueType); err != nil {
-			return nil, thrift.PrependError("error while reading map", err)
+			return nil, thrift.PrependError("error while reading map: ", err)
 		}
 	}
 
-	res := NewTMap(&tmap)
+	res := NewTMap(keyType, valueType, &tmap)
 	return res, nil
 }
 

--- a/tmap_test.go
+++ b/tmap_test.go
@@ -1,0 +1,360 @@
+package thrift
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+func TestEquals_Equals(t *testing.T) {
+	// prepare
+	a := NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 1"): NewTBool(false),
+			NewTstring("key 2"): NewTBool(true),
+		},
+	)
+	var b TValue
+	b = NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 2"): NewTBool(true),
+			NewTstring("key 1"): NewTBool(false),
+		},
+	)
+	expected := true
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestEquals_DifferentValue(t *testing.T) {
+	// prepare
+	a := NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 1"): NewTBool(false),
+			NewTstring("key 2"): NewTBool(true),
+		},
+	)
+	var b TValue
+	b = NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 1"): NewTBool(false),
+			NewTstring("key 2"): NewTBool(false),
+		},
+	)
+	expected := false
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestEquals_DifferentKeyValueCount(t *testing.T) {
+	// prepare
+	a := NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 1"): NewTBool(false),
+			NewTstring("key 2"): NewTBool(false),
+		},
+	)
+	var b TValue
+	b = NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 1"): NewTBool(false),
+			NewTstring("key 2"): NewTBool(false),
+			NewTstring("key 3"): NewTBool(false),
+		},
+	)
+	expected := false
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestEquals_OtherKeyValueType(t *testing.T) {
+	// prepare
+	a := NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 1"): NewTBool(false),
+		},
+	)
+	var b TValue
+	b = NewTMap(
+		thrift.BOOL,
+		thrift.STRING,
+		&map[TValue]TValue{
+			NewTBool(false): NewTBool(false),
+		},
+	)
+	expected := false
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestEquals_OtherType(t *testing.T) {
+	// prepare
+	a := NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 1"): NewTBool(false),
+			NewTstring("key 2"): NewTBool(true),
+		},
+	)
+	var b TValue
+	b = NewTstring("other")
+	expected := false
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestWriteFieldData_TMap(t *testing.T) {
+	// prepare
+	oprot := setupProtocol(t)
+	cxt := context.Background()
+	value := NewTMap(
+		thrift.STRING,
+		thrift.BOOL,
+		&map[TValue]TValue{
+			NewTstring("key 1"): NewTBool(false),
+			NewTstring("key 2"): NewTBool(true),
+		},
+	)
+
+	// do
+	err := value.WriteFieldData(cxt, oprot)
+	checkError(t, err)
+
+	// verify
+	oprot.Flush(cxt)
+	{
+		ktype, vtype, size, err := oprot.ReadMapBegin(cxt)
+		assert(t, "size", size, 2)
+		checkError(t, err)
+		assert(t, "key type", ktype, thrift.STRING)
+		assert(t, "value type", vtype, thrift.BOOL)
+	}
+	{
+		k, err := oprot.ReadString(cxt)
+		checkError(t, err)
+		assert(t, "key 1", k, "key 1")
+	}
+	{
+		v, err := oprot.ReadBool(cxt)
+		checkError(t, err)
+		assert(t, "key 1 value", v, false)
+	}
+	{
+		k, err := oprot.ReadString(cxt)
+		checkError(t, err)
+		assert(t, "key 2", k, "key 2")
+	}
+	{
+		v, err := oprot.ReadBool(cxt)
+		checkError(t, err)
+		assert(t, "key 2 value", v, true)
+	}
+	{
+		err := oprot.ReadMapEnd(cxt)
+		checkError(t, err)
+	}
+}
+
+func TestReadMap_StringToBool(t *testing.T) {
+	// prepare
+	iprot := setupProtocol(t)
+	cxt := context.Background()
+	{
+		checkError(
+			t,
+			iprot.WriteMapBegin(cxt, thrift.STRING, thrift.BOOL, 2),
+		)
+		checkError(
+			t,
+			iprot.WriteString(cxt, "key 1"),
+		)
+		checkError(
+			t,
+			iprot.WriteBool(cxt, true),
+		)
+		checkError(
+			t,
+			iprot.WriteString(cxt, "key 2"),
+		)
+		checkError(
+			t,
+			iprot.WriteBool(cxt, false),
+		)
+		checkError(
+			t,
+			iprot.WriteMapEnd(cxt),
+		)
+		checkError(
+			t,
+			iprot.Flush(cxt),
+		)
+	}
+
+	// do
+	actual, err := ReadMap(cxt, iprot)
+	checkError(t, err)
+
+	// verfiy
+	a, ok := actual.(*TMap)
+	assertTrue(t, "cast to TMap", ok)
+	{
+		assertTrue(t, "size", len((*a).value) == 2)
+	}
+	{
+		tv := (*a).value[NewTstring("key 1")]
+		v, ok := tv.(TBool)
+		assertTrue(t, "cast key 1 value to TBool", ok)
+		assert(t, "key 1 value", v.value, true)
+	}
+	{
+		tv := (*a).value[NewTstring("key 2")]
+		v, ok := tv.(TBool)
+		assertTrue(t, "cast key 2 to TBool", ok)
+		assert(t, "key 2 value", v.value, false)
+	}
+}
+
+func TestReadMap_ContainerData(t *testing.T) {
+	// prepare
+	iprot := setupProtocol(t)
+	cxt := context.Background()
+	{
+		checkError(
+			t,
+			iprot.WriteMapBegin(cxt, thrift.STRING, thrift.STRUCT, 1),
+		)
+		// key
+		checkError(
+			t,
+			iprot.WriteString(cxt, "key"),
+		)
+		// value
+		checkError(
+			t,
+			iprot.WriteStructBegin(cxt, "struct"),
+		)
+
+		checkError(
+			t,
+			iprot.WriteFieldBegin(cxt, "string", thrift.STRING, 1),
+		)
+		checkError(
+			t,
+			iprot.WriteString(cxt, "string string"),
+		)
+		checkError(
+			t,
+			iprot.WriteFieldEnd(cxt),
+		)
+
+		checkError(
+			t,
+			iprot.WriteFieldBegin(cxt, "boolean", thrift.BOOL, 2),
+		)
+		checkError(
+			t,
+			iprot.WriteBool(cxt, true),
+		)
+		checkError(
+			t,
+			iprot.WriteFieldEnd(cxt),
+		)
+
+		checkError(
+			t,
+			iprot.WriteFieldStop(cxt),
+		)
+		checkError(
+			t,
+			iprot.WriteStructEnd(cxt),
+		)
+
+		checkError(
+			t,
+			iprot.WriteMapEnd(cxt),
+		)
+		checkError(
+			t,
+			iprot.Flush(cxt),
+		)
+	}
+
+	// do
+	actual, err := ReadMap(cxt, iprot)
+	checkError(t, err)
+
+	// verfiy
+	a, ok := actual.(*TMap)
+	assertTrue(t, "cast to TMap", ok)
+	{
+		assertTrue(t, "size", len((*a).value) == 1)
+	}
+	tv := (*a).value[NewTstring("key")]
+	v, ok := tv.(*TStruct)
+	assertTrue(t, "cast key 1 value to TStruct", ok)
+	{
+		tf := v.value[TStructField{id: 1, name: ""}]
+		f, ok := tf.(TString)
+		assertTrue(t, "cast field 1 to TString", ok)
+		assert(t, "field string", f.value, "string string")
+	}
+	{
+		tf := v.value[TStructField{id: 2, name: ""}]
+		f, ok := tf.(TBool)
+		assertTrue(t, "cast field 2 to TBool", ok)
+		assert(t, "field boolean", f.value, true)
+	}
+}
+
+func TestReadBool_Invalid_type(t *testing.T) {
+	// prepare
+	iprot := setupProtocol(t)
+	cxt := context.Background()
+	{
+		var err error
+		err = iprot.WriteString(cxt, "other")
+		checkError(t, err)
+	}
+
+	// do
+	_, err := ReadMap(cxt, iprot)
+
+	// verfiy
+	assertTrue(t, "", err != nil)
+}

--- a/tmap_test.go
+++ b/tmap_test.go
@@ -342,8 +342,7 @@ func TestReadBool_Invalid_type(t *testing.T) {
 	iprot := setupProtocol(t)
 	cxt := context.Background()
 	{
-		var err error
-		err = iprot.WriteString(cxt, "other")
+		err := iprot.WriteString(cxt, "other")
 		checkError(t, err)
 	}
 

--- a/tmap_test.go
+++ b/tmap_test.go
@@ -17,8 +17,7 @@ func TestEquals_Equals(t *testing.T) {
 			NewTstring("key 2"): NewTBool(true),
 		},
 	)
-	var b TValue
-	b = NewTMap(
+	var b TValue = NewTMap(
 		thrift.STRING,
 		thrift.BOOL,
 		&map[TValue]TValue{
@@ -45,8 +44,7 @@ func TestEquals_DifferentValue(t *testing.T) {
 			NewTstring("key 2"): NewTBool(true),
 		},
 	)
-	var b TValue
-	b = NewTMap(
+	var b TValue = NewTMap(
 		thrift.STRING,
 		thrift.BOOL,
 		&map[TValue]TValue{
@@ -73,8 +71,7 @@ func TestEquals_DifferentKeyValueCount(t *testing.T) {
 			NewTstring("key 2"): NewTBool(false),
 		},
 	)
-	var b TValue
-	b = NewTMap(
+	var b TValue = NewTMap(
 		thrift.STRING,
 		thrift.BOOL,
 		&map[TValue]TValue{
@@ -101,8 +98,7 @@ func TestEquals_OtherKeyValueType(t *testing.T) {
 			NewTstring("key 1"): NewTBool(false),
 		},
 	)
-	var b TValue
-	b = NewTMap(
+	var b TValue = NewTMap(
 		thrift.BOOL,
 		thrift.STRING,
 		&map[TValue]TValue{
@@ -128,8 +124,7 @@ func TestEquals_OtherType(t *testing.T) {
 			NewTstring("key 2"): NewTBool(true),
 		},
 	)
-	var b TValue
-	b = NewTstring("other")
+	var b TValue = NewTstring("other")
 	expected := false
 
 	// do


### PR DESCRIPTION
# Overview

Improve testing.

# What's changed

- Write unit test for `tmap.go`.
  - `Equal()`
  - `WriteFieldData()` and assert it with Thrift's native read method.
  - `ReadMap()` and assert it using Thrift's native write method.
- Change `NewTMap()` method to accept key/value `TType`.
  - Required in here.
    - https://github.com/lavenderses/xk6-thrift/blob/78b888719656175ed178a738c42dc2c43f7db336/tmap.go#L46
