### PR TITLE
Add new type support for Thrift Enum

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -31,7 +31,7 @@ func assertTrue(t *testing.T, title string, result bool) {
 	assert(t, title, result, true)
 }
 
-func assert[T string | bool | int | int16 | thrift.TType](t *testing.T, title string, actual, expected T) {
+func assert[T string | bool | int | int16 | int32 | thrift.TType](t *testing.T, title string, actual, expected T) {
 	if actual != expected {
 		t.Fatalf("[%v] Expected %v but was %v", title, expected, actual)
 	}

--- a/it/test_service_test.go
+++ b/it/test_service_test.go
@@ -341,3 +341,35 @@ func TestStringsCall(t *testing.T) {
 
 	assertEquals(t, *actual, *expect)
 }
+
+func TestEnumCall(t *testing.T) {
+	// prepare
+	var client *thrift.TStandardClient
+	var err error
+	if client, err = setupClient(t); err != nil {
+		t.Fatalf("error creating client. %v", err)
+	}
+
+	cxt := context.Background()
+	method := "enumCall"
+	tvalue := map[int16]xk6_thrift.TValue{
+		1: xk6_thrift.NewTEnum(1), // ONE
+	}
+	arg := xk6_thrift.NewTRequestWithValue(&tvalue)
+	expectValue := []xk6_thrift.TValue{
+		xk6_thrift.NewTEnum(1), // ONE
+		xk6_thrift.NewTEnum(2), // TWO
+		xk6_thrift.NewTEnum(3), // THREE
+	}
+	expectTValue := xk6_thrift.NewTList(&expectValue, thrift.I32)
+	expect := xk6_thrift.NewTResponse()
+	expect.Add(0, expectTValue)
+	actual := xk6_thrift.NewTResponse()
+
+	// do & verify
+	if _, err = (*client).Call(cxt, method, arg, actual); err != nil {
+		t.Fatalf("error calling RPC. %v", err)
+	}
+
+	assertEquals(t, *actual, *expect)
+}

--- a/tcontainer.go
+++ b/tcontainer.go
@@ -11,6 +11,9 @@ func ReadContainerData(ttype thrift.TType, cxt context.Context, iprot thrift.TPr
 	var err error
 
 	switch ttype {
+	// FIXME: i32 duplication for enum / int32. change the way to determine
+	case thrift.I32:
+		tv, err = ReadEnum(cxt, iprot)
 	case thrift.STRING:
 		tv, err = ReadString(cxt, iprot)
 	case thrift.BOOL:

--- a/tenum.go
+++ b/tenum.go
@@ -1,0 +1,52 @@
+package thrift
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type TEnum struct {
+	value int32
+}
+
+func NewTEnum(v int32) TEnum {
+	return TEnum{value: v}
+}
+
+func (p TEnum) Equals(other *TValue) bool {
+	o, ok := (*other).(TEnum)
+	if !ok {
+		return false
+	}
+	return p.value == o.value
+}
+
+// See [Thrift IDL protocol spec]
+//
+//	<field> ::= <field-begin> <field-data> <field-end>
+//	<field-data> ::= I32
+//
+// [Thrift IDL protocol spec]: https://github.com/apache/thrift/blob/eec0b584e657e4250e22f3fd492858d632e2aa7b/doc/specs/thrift-protocol-spec.md
+func (p TEnum) WriteFieldData(cxt context.Context, oprot thrift.TProtocol) error {
+	err := oprot.WriteI32(cxt, p.value)
+	if err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.id (1) field write error: ", p), err)
+	}
+	return nil
+}
+
+func (p TEnum) TType() thrift.TType {
+	return thrift.I32
+}
+
+func ReadEnum(cxt context.Context, iproto thrift.TProtocol) (TValue, error) {
+	v, err := iproto.ReadI32(cxt)
+	if err != nil {
+		return nil, thrift.PrependError("error while reading i32 field", err)
+	}
+
+	res := NewTEnum(v)
+	return res, nil
+}

--- a/tenum_test.go
+++ b/tenum_test.go
@@ -1,0 +1,107 @@
+package thrift
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEquals_TEnum_Equals(t *testing.T) {
+	// prepare
+	a := NewTEnum(3)
+	var b TValue = NewTEnum(3)
+	expected := true
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestEquals_TEnum_NotEquals(t *testing.T) {
+	// prepare
+	a := NewTEnum(3)
+	var b TValue = NewTEnum(1)
+	expected := false
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestEquals_TEnum_OtherType(t *testing.T) {
+	// prepare
+	a := NewTEnum(3)
+	var b TValue = NewTBool(false)
+	expected := false
+
+	// do
+	actual := a.Equals(&b)
+
+	// verify
+	assert(t, "", actual, expected)
+}
+
+func TestWriteFieldData_Enum(t *testing.T) {
+	// prepare
+	oprot := setupProtocol(t)
+	cxt := context.Background()
+	value := NewTEnum(3)
+	var expected int32 = 3
+
+	// do
+	err := value.WriteFieldData(cxt, oprot)
+	checkError(t, err)
+
+	// verify
+	oprot.Flush(cxt)
+	actual, err := oprot.ReadI32(cxt)
+	checkError(t, err)
+	assert(t, "", actual, expected)
+}
+
+func TestReadEnum(t *testing.T) {
+	// prepare
+	iprot := setupProtocol(t)
+	cxt := context.Background()
+	checkError(
+		t,
+		iprot.WriteI32(cxt, 3),
+	)
+	checkError(
+		t,
+		iprot.Flush(cxt),
+	)
+
+	// do
+	actual, err := ReadEnum(cxt, iprot)
+	checkError(t, err)
+
+	// verfiy
+	e := NewTEnum(3)
+	a, ok := actual.(TEnum)
+	assertTrue(t, "cast to TEnum", ok)
+	assert(t, "result", a.value, e.value)
+}
+
+func TestReadEnum_InvalidType(t *testing.T) {
+	// prepare
+	iprot := setupProtocol(t)
+	cxt := context.Background()
+	checkError(
+		t,
+		iprot.WriteString(cxt, "foo"),
+	)
+	checkError(
+		t,
+		iprot.Flush(cxt),
+	)
+
+	// do
+	_, err := ReadEnum(cxt, iprot)
+
+	// verfiy
+	assertTrue(t, "error expected", err != nil)
+}


### PR DESCRIPTION
# Overview

New support of type Enum in xk6-thrift.

# What's changed

Following.
- https://github.com/lavenderses/xk6-thrift/pull/40

----

- Add new type `TEnum`, representing Enum type in Thrift.
- Add read and write method for `TEnum`.
